### PR TITLE
Add support for armv7l arch

### DIFF
--- a/vars/main.yml
+++ b/vars/main.yml
@@ -19,6 +19,9 @@ k3s_arch_lookup:
   arm7:
     arch: arm
     suffix: "-armhf"
+  armv7l:
+    arch: arm
+    suffix: "-armhf"
   armhf:
     arch: arm
     suffix: "-armhf"


### PR DESCRIPTION
I was receiving this error when running the task on my [Odroid HC1 running Armbian](https://www.armbian.com/odroid-hc1/):

```
TASK [xanmanning.k3s : Ensure target host architecture information is set as a fact] **************************************************************************
fatal: [odroid]: FAILED! => {"msg": "The task includes an option with an undefined variable. The error was: 'dict object' has no attribute 'armv7l'\n\nThe error appears to have been in '/home/jdmarble/.ansible/roles/xanmanning.k3s/tasks/download-k3s.yml': line 3, column 3, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n\n- name: Ensure target host architecture information is set as a fact\n  ^ here\n"}
```

I worked around the problem by overriding `k3s_arch_lookup` in my play book:

```yaml
---

- hosts: all
  roles:
    - role: xanmanning.k3s
      k3s_arch_lookup:
        armv7l:
          arch: arm
          suffix: "-armhf"
```