### PR TITLE
Use correct checksums for arm downloads

### DIFF
--- a/tasks/build/download-k3s.yml
+++ b/tasks/build/download-k3s.yml
@@ -18,7 +18,7 @@
 
 - name: Ensure sha256sum is set from hashsum variable
   set_fact:
-    k3s_hash_sum: "{{ (k3s_hash_sum_raw.content.split('\n') | select('search', 'k3s') | first).split() | first }}"
+    k3s_hash_sum: "{{ (k3s_hash_sum_raw.content.split('\n') | reject('search', 'images') | first).split() | first }}"
   changed_when: false
 
 - name: Ensure installation directory exists


### PR DESCRIPTION
I attempted to install on arm64 and armhf. Both fail because the [checksum filter](https://github.com/PyratLabs/ansible-role-k3s/blob/e07903a5cf86fb9c8b04a4b38eb99a8dad86354b/tasks/build/download-k3s.yml#L21) finds the first line with "k3s". On the arm checksum files, the first lines are for "k3s-airgap-images-arm64.tar" and "k3s-airgap-images-arm.tar" so the wrong checksum is grabbed.

I attempted to fix this with a more specific filter: `select('search', 'k3s'+k3s_arch_suffix)`.
This works for both arm architectures, but fails for amd64 because the key is simply "k3s" and not "k3s-amd64".

The solution I settled on is not ideal for future proofing, but works for now at least.