### PR TITLE
Variable check for local storage path

### DIFF
--- a/tasks/validate/check-variables.yml
+++ b/tasks/validate/check-variables.yml
@@ -197,3 +197,11 @@
     success_msg: "--datastore-endpoint supported in {{ k3s_release_version }}"
     fail_msg: "--datastore-endpoint not supported in {{ k3s_release_version }}"
   when: k3s_datastore_keyfile is defined and k3s_datastore_keyfile
+
+- name: Check k3s_default_local_storage_path against k3s version
+  assert:
+    that:
+      - (k3s_release_version | replace('v', '')) is version_compare('1.0.0', '>=')
+    success_msg: "Local storage path supported in {{ k3s_release_version }}"
+    fail_msg: "Local storage path are not supported in {{ k3s_release_version }}"
+  when: k3s_default_local_storage_path is defined and k3s_default_local_storage_path


### PR DESCRIPTION
Checks were missing for the --default-local-storage-path option, these have been added to validation scripts.