### PR TITLE
Become superuser to solve "Access denied"

### DIFF
--- a/tasks/build/configure-k3s-cluster.yml
+++ b/tasks/build/configure-k3s-cluster.yml
@@ -32,6 +32,7 @@
   retries: "{{ play_hosts | length }}"
   delay: 2
   when: k3s_control_node and not k3s_primary_control_node
+  become: "{{ k3s_become_for_systemd | ternary(true, false, k3s_become_for_all) }}"
 
 - name: Wait for control plane to be ready to accept connections
   wait_for:


### PR DESCRIPTION
```
FAILED! => {"attempts": 3, "changed": false, "msg": "Unable to enable service k3s: Failed to enable unit: Access denied\n"}
```

The task never sets become to true, hence failing due to lack of permissions on the user that is executing it by default.