### PR TITLE
Set LimitNOFILE to 1048576 in k3s systemd file

### DIFF
--- a/templates/k3s.service.j2
+++ b/templates/k3s.service.j2
@@ -182,7 +182,7 @@ ExecStart={{ k3s_install_dir }}/k3s
 
 KillMode=process
 Delegate=yes
-LimitNOFILE=infinity
+LimitNOFILE=1048576
 LimitNPROC=infinity
 LimitCORE=infinity
 TasksMax=infinity


### PR DESCRIPTION
Apparently using `infinity` doesn't work anymore, see the following issue:

https://github.com/containerd/containerd/issues/3201

This number is also referenced in the k3s install script at https://get.k3s.io