### PR TITLE
set want and after to network-online.target in systemd file

### DIFF
--- a/templates/k3s.service.j2
+++ b/templates/k3s.service.j2
@@ -1,7 +1,8 @@
 [Unit]
 Description=Lightweight Kubernetes
 Documentation=https://k3s.io
-After=network.target
+Wants=network-online.target
+After=network-online.target
 
 [Service]
 Type={{ 'notify' if k3s_control_node else 'exec' }}


### PR DESCRIPTION
We had `After=network.target` when the upstream bash installer is `After=network-online.target`.

I have also included this change in the following PR

https://github.com/rancher/k3s/pull/2210