### PR TITLE
Implement installing specific k3s commit

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ k3s_release_version: stable                                    # latest 'stable'
 k3s_release_version: testing                                   # latest 'testing' release
 k3s_release_version: v1.18                                     # latest v1.18 release
 k3s_release_version: v1.17-testing                             # latest v1.17 testing release
+k3s_release_version: v1.19.2-k3s1                              # specific version
 k3s_release_version: 48ed47c4a3e420fa71c18b2ec97f13dc0659778b  # specific commit - must be 40 characters
 ```
 

--- a/README.md
+++ b/README.md
@@ -119,11 +119,12 @@ It is also possible to install specific K3s "Channels", below are some
 examples for `k3s_release_version`:
 
 ```yaml
-k3s_release_version: false          # defaults to 'stable' channel
-k3s_release_version: stable         # latest 'stable' release
-k3s_release_version: testing        # latest 'testing' release
-k3s_release_version: v1.18          # latest v1.18 release
-k3s_release_version: v1.17-testing  # latest v1.17 testing release
+k3s_release_version: false                                     # defaults to 'stable' channel
+k3s_release_version: stable                                    # latest 'stable' release
+k3s_release_version: testing                                   # latest 'testing' release
+k3s_release_version: v1.18                                     # latest v1.18 release
+k3s_release_version: v1.17-testing                             # latest v1.17 testing release
+k3s_release_version: 48ed47c4a3e420fa71c18b2ec97f13dc0659778b  # specific commit - must be 40 characters
 ```
 
 #### Important node about `k3s_install_hard_links`

--- a/README.md
+++ b/README.md
@@ -119,13 +119,16 @@ It is also possible to install specific K3s "Channels", below are some
 examples for `k3s_release_version`:
 
 ```yaml
-k3s_release_version: false                                     # defaults to 'stable' channel
-k3s_release_version: stable                                    # latest 'stable' release
-k3s_release_version: testing                                   # latest 'testing' release
-k3s_release_version: v1.18                                     # latest v1.18 release
-k3s_release_version: v1.17-testing                             # latest v1.17 testing release
-k3s_release_version: v1.19.2-k3s1                              # specific version
-k3s_release_version: 48ed47c4a3e420fa71c18b2ec97f13dc0659778b  # specific commit - must be 40 characters
+k3s_release_version: false             # defaults to 'stable' channel
+k3s_release_version: stable            # latest 'stable' release
+k3s_release_version: testing           # latest 'testing' release
+k3s_release_version: v1.18             # latest v1.18 release
+k3s_release_version: v1.17-testing     # latest v1.17 testing release
+k3s_release_version: v1.19.2-k3s1      # specific release
+
+# specific commit
+# only be used for tesing - must be 40 characters
+k3s_release_version: 48ed47c4a3e420fa71c18b2ec97f13dc0659778b
 ```
 
 #### Important node about `k3s_install_hard_links`

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ consistency.
 | `k3s_etcd_snapshot_schedule_cron`        | Etcd snapshot cron schedule.                                                        | "`* */12 * * *`"                           |
 | `k3s_etcd_snapshot_retention`            | Etcd snapshot retention.                                                            | 5                                          |
 | `k3s_etcd_snapshot_directory`            | Etcd snapshot directory.                                                            | `/var/lib/rancher/k3s/server/db/snapshots` |
-| `k3s_secrets_encryption`                 | Use secrets encryption at rest. (EXPERIMENTAL)                                      | `f   alse`                                 |
+| `k3s_secrets_encryption`                 | Use secrets encryption at rest. (EXPERIMENTAL)                                      | `false`                                 |
 | `k3s_debug`                              | Enable debug logging on the k3s service                                             | `false`                                    |
 | `k3s_enable_selinux`                     | Enable SELinux in containerd. (EXPERIMENTAL)                                        | `false`                                    |
 

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ k3s_release_version: v1.17-testing     # latest v1.17 testing release
 k3s_release_version: v1.19.2-k3s1      # specific release
 
 # specific commit
-# only be used for tesing - must be 40 characters
+# caution - only used for tesing - must be 40 characters
 k3s_release_version: 48ed47c4a3e420fa71c18b2ec97f13dc0659778b
 ```
 

--- a/tasks/build/download-k3s.yml
+++ b/tasks/build/download-k3s.yml
@@ -12,6 +12,14 @@
     k3s_hash_url: "{{ k3s_github_download_url }}/{{ k3s_release_version }}/sha256sum-{{ k3s_arch }}.txt"
   check_mode: false
 
+- name: Override k3s_binary_url and k3s_hash_url facts for testing specific commit
+  set_fact:
+    k3s_binary_url: "https://storage.googleapis.com/k3s-ci-builds/k3s{{ k3s_arch_suffix }}-{{ k3s_release_version }}"
+    k3s_hash_url: "https://storage.googleapis.com/k3s-ci-builds/k3s{{ k3s_arch_suffix }}-{{ k3s_release_version }}.sha256sum"
+  when:
+    - k3s_release_version | regex_search("^[a-z0-9]{40}$")
+  check_mode: false
+
 - name: Ensure the k3s hashsum is downloaded
   uri:
     url: "{{ k3s_hash_url }}"


### PR DESCRIPTION
This will allow people to specify a commit if they wish to test out changes not yet merged to master.

I verified this worked with a test install:

vars:

```yaml
k3s_release_version: "48ed47c4a3e420fa71c18b2ec97f13dc0659778b"
```

k3s version:

```
k3s --version
k3s version v1.19.2+k3s-48ed47c4 (48ed47c4)
```

ansible output:

```
TASK [xanmanning.k3s : Ensure URLs are set as facts for downloading binaries] ******************************************************************************
Wednesday 23 September 2020  09:38:28 -0400 (0:00:00.068)       0:00:09.652 ***
ok: [k8s-master-a]
ok: [k8s-master-b]
ok: [k8s-master-c]

TASK [xanmanning.k3s : Override k3s_binary_url and k3s_hash_url facts for testing specific commit] *********************************************************
Wednesday 23 September 2020  09:38:29 -0400 (0:00:00.073)       0:00:09.726 ***
ok: [k8s-master-a]
ok: [k8s-master-b]
ok: [k8s-master-c]
```

Closes #51 