### PR TITLE
Implement option to disable kube-proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ consistency.
 | `k3s_disable_scheduler`                  | Disable Kubernetes default scheduler                                                | `false`                                    |
 | `k3s_disable_cloud_controller`           | Disable k3s default cloud controller manager.                                       | `false`                                    |
 | `k3s_disable_network_policy`             | Disable k3s default network policy controller.                                      | `false`                                    |
+| `k3s_disable_kube_proxy`                 | Disable k3s default kube proxy.                                                     | `false`                                    |
 | `k3s_write_kubeconfig_mode`              | Define the file mode from the generated KubeConfig, eg. `644`                       | _NULL_                                     |
 | `k3s_datastore_endpoint`                 | Define the database or etcd cluster endpoint for HA.                                | _NULL_                                     |
 | `k3s_datastore_cafile`                   | Define the database TLS CA file.                                                    | _NULL_                                     |

--- a/templates/k3s.service.j2
+++ b/templates/k3s.service.j2
@@ -34,6 +34,9 @@ ExecStart={{ k3s_install_dir }}/k3s
     {% if k3s_disable_network_policy %}
         --disable-network-policy
     {% endif %}
+    {% if k3s_disable_kube_proxy %}
+        --disable-kube-proxy
+    {% endif %}
     {% if k3s_no_flannel %}
         {% if (k3s_release_version | replace('v', '')) is version_compare('1.0.0', '>=')  %}
             --flannel-backend none


### PR DESCRIPTION
This is undocumented but it is in k3s v1.19 and up, it maybe backported to v1.18 via [this PR](https://github.com/rancher/k3s/pull/1935). Disabling kube-proxy allows use to set kube-router instead.

https://github.com/rancher/k3s/blob/v1.19.1%2Bk3s1/pkg/cli/server/server.go#L111