### PR TITLE
Implement setting multiple k3s_tls_san

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,21 +209,21 @@ Please note that this may potentially break setting up agents.
 
 Below are variables that are set against specific hosts in your inventory.
 
-| Variable                    | Description                                                              | Default Value          |
-|-----------------------------|--------------------------------------------------------------------------|------------------------|
-| `k3s_control_node`          | Define the host as a control plane node, (True/False).                   | `false`                |
-| `k3s_node_name`             | Define the name of this node.                                            | `$(hostname)`          |
-| `k3s_node_id`               | Define the ID of this node.                                              | _NULL_                 |
-| `k3s_flannel_interface`     | Define the flannel proxy interface for this node.                        | _NULL_                 |
-| `k3s_bind_address`          | Define the bind address for this node.                                   | localhost              |
-| `k3s_node_ip_address`       | IP Address to advertise for this node.                                   | _NULL_                 |
-| `k3s_node_external_address` | External IP Address to advertise for this node.                          | _NULL_                 |
-| `k3s_node_labels`           | List of node labels.                                                     | _NULL_                 |
-| `k3s_kubelet_args`          | A list of kubelet args to pass to the server.                            | []                     |
-| `k3s_kube_proxy_args`       | A list of kube proxy args to pass to the server.                         | []                     |
-| `k3s_node_taints`           | List of node taints.                                                     | _NULL_                 |
-| `k3s_node_data_dir`         | Folder to hold state.                                                    | `/var/lib/rancher/k3s` |
-| `k3s_tls_san`               | Add additional hosname or IP as Subject Alternate Name in the TLS cert.  | _NULL_                 |
+| Variable                    | Description                                                                      | Default Value          |
+|-----------------------------|----------------------------------------------------------------------------------|------------------------|
+| `k3s_control_node`          | Define the host as a control plane node, (True/False).                           | `false`                |
+| `k3s_node_name`             | Define the name of this node.                                                    | `$(hostname)`          |
+| `k3s_node_id`               | Define the ID of this node.                                                      | _NULL_                 |
+| `k3s_flannel_interface`     | Define the flannel proxy interface for this node.                                | _NULL_                 |
+| `k3s_bind_address`          | Define the bind address for this node.                                           | localhost              |
+| `k3s_node_ip_address`       | IP Address to advertise for this node.                                           | _NULL_                 |
+| `k3s_node_external_address` | External IP Address to advertise for this node.                                  | _NULL_                 |
+| `k3s_node_labels`           | List of node labels.                                                             | _NULL_                 |
+| `k3s_kubelet_args`          | A list of kubelet args to pass to the server.                                    | []                     |
+| `k3s_kube_proxy_args`       | A list of kube proxy args to pass to the server.                                 | []                     |
+| `k3s_node_taints`           | List of node taints.                                                             | _NULL_                 |
+| `k3s_node_data_dir`         | Folder to hold state.                                                            | `/var/lib/rancher/k3s` |
+| `k3s_tls_san`               | A list of additional hosnames or IPs as Subject Alternate Name in the TLS cert.  | []                     |
 
 #### Important note about `k3s_control_node` and High Availability (HA)
 

--- a/templates/k3s.service.j2
+++ b/templates/k3s.service.j2
@@ -142,8 +142,14 @@ ExecStart={{ k3s_install_dir }}/k3s
 {% if k3s_resolv_conf is defined and k3s_resolv_conf %}
     --resolv-conf {{ k3s_resolv_conf }}
 {% endif %}
-{% if k3s_tls_san is defined and k3s_tls_san %}
-    --tls-san {{ k3s_tls_san }}
+{% if k3s_tls_san is defined and k3s_tls_san is iterable %}
+    {% for san in k3s_tls_san %}
+        --tls-san {{ san }}
+    {% endfor %}
+{% else %}
+    {% if k3s_tls_san is defined and k3s_tls_san %}
+        --tls-san {{ k3s_tls_san }}
+    {% endif %}
 {% endif %}
 {% if k3s_node_data_dir is defined %}
     --data-dir {{ k3s_node_data_dir }}


### PR DESCRIPTION
According to the docs at https://rancher.com/docs/k3s/latest/en/installation/ha/#3-configure-the-fixed-registration-address we can set multiple TLS sans

This also keeps support for non lists