### PR TITLE
k3s_node_data_dir now set in templates

### DIFF
--- a/tasks/build/configure-k3s-cluster.yml
+++ b/tasks/build/configure-k3s-cluster.yml
@@ -2,7 +2,7 @@
 
 - name: Ensure NODE_TOKEN is captured from control node
   slurp:
-    path: "/var/lib/rancher/k3s/server/node-token"
+    path: "{{ k3s_node_data_dir | default ('/var/lib/rancher/k3s') }}/server/node-token"
   register: k3s_slurped_control_token
   delegate_to: "{{ k3s_control_delegate }}"
   when: k3s_control_token is not defined and not ansible_check_mode

--- a/templates/k3s-killall.sh.j2
+++ b/templates/k3s-killall.sh.j2
@@ -2,7 +2,7 @@
 
 [ $(id -u) -eq 0 ] || exec sudo $0 $@
 
-for bin in /var/lib/rancher/k3s/data/**/bin/; do
+for bin in {{ k3s_node_data_dir | default('/var/lib/rancher/k3s') }}/data/**/bin/; do
     [ -d "$bin" ] && export PATH=$bin:$PATH
 done
 
@@ -62,7 +62,7 @@ do_unmount() {
 }
 
 do_unmount '/run/k3s'
-do_unmount '/var/lib/rancher/k3s'
+do_unmount '{{ k3s_node_data_dir | default('/var/lib/rancher/k3s') }}'
 do_unmount '/var/lib/kubelet/pods'
 do_unmount '/run/netns/cni-'
 

--- a/templates/k3s-uninstall.sh.j2
+++ b/templates/k3s-uninstall.sh.j2
@@ -55,7 +55,7 @@ for bin in {{ k3s_install_dir }}/k3s*; do
 done
 
 [ -d /etc/rancher/k3s ] && rm -rf /etc/rancher/k3s
-[ -d /var/lib/rancher/k3s ] && rm -rf /var/lib/rancher/k3s
+[ -d {{ k3s_node_data_dir | default('/var/lib/rancher/k3s') }} ] && rm -rf {{ k3s_node_data_dir | default('/var/lib/rancher/k3s') }}
 [ -d /var/lib/kubelet ] && rm -rf /var/lib/kubelet
 
 [ -f /usr/local/bin/k3s-killall.sh ] && rm -f /usr/local/bin/k3s-killall.sh


### PR DESCRIPTION
`k3s_node_data_dir` was hard coded into a number of templates, this causes problems with collection of NODE_TOKEN and uninstall as described in #57 

This change removes hard-coded values and replaces them with the variable.