### PR TITLE
add advertise_ip support

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,7 @@ Below are variables that are set against specific hosts in your inventory.
 | `k3s_node_name`             | Define the name of this node.                                                    | `$(hostname)`          |
 | `k3s_node_id`               | Define the ID of this node.                                                      | _NULL_                 |
 | `k3s_flannel_interface`     | Define the flannel proxy interface for this node.                                | _NULL_                 |
+| `k3s_advertise_address`     | Define the advertise address for this node.                                      | _NULL_                 |
 | `k3s_bind_address`          | Define the bind address for this node.                                           | localhost              |
 | `k3s_node_ip_address`       | IP Address to advertise for this node.                                           | _NULL_                 |
 | `k3s_node_external_address` | External IP Address to advertise for this node.                                  | _NULL_                 |

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -80,7 +80,7 @@ k3s_use_docker: false
 # Disable flannel, you will need to install your own CNI driver.
 k3s_no_flannel: false
 
-# Flannel backend ('none', 'vxlan', 'ipsec', or 'wireguard')
+# Flannel backend ('none', 'vxlan', 'ipsec', 'host-gw' or 'wireguard')
 # k3s_flannel_backend: vxlan
 
 # Disable CoreDNS, you will need to install your own DNS provider.

--- a/templates/k3s.service.j2
+++ b/templates/k3s.service.j2
@@ -19,6 +19,9 @@ ExecStart={{ k3s_install_dir }}/k3s
     {% if k3s_bind_address is defined %}
         --bind-address {{ k3s_bind_address }}
     {% endif %}
+    {% if k3s_advertise_address is defined %}
+        --advertise-address {{ k3s_advertise_address }}
+    {% endif %}    
     {% if k3s_non_root is defined and k3s_non_root %}
         --rootless
     {% endif %}


### PR DESCRIPTION
during my work on a rpi cluster with 2 network interfaces i wanted to use the vlan ips for advertising

this pr adds a variable to optionally define `k3s_advertise_address`