### PR TITLE
adding retries to restart k3s handler

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -12,6 +12,8 @@
     state: restarted
     scope: "{{ k3s_systemd_context }}"
     enabled: true
+  retries: 3
+  delay: 3  
   become: "{{ k3s_become_for_systemd | ternary(true, false, k3s_become_for_all) }}"
 
 - name: restart docker

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -13,7 +13,7 @@
     scope: "{{ k3s_systemd_context }}"
     enabled: true
   retries: 3
-  delay: 3  
+  delay: 3
   become: "{{ k3s_become_for_systemd | ternary(true, false, k3s_become_for_all) }}"
 
 - name: restart docker


### PR DESCRIPTION
during my experiments i faced issues with the restart k3s handler on rpi nodes
they took too long

added retries to workaround this