### PR TITLE
Uninstall scripts now in-line with upstream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,16 @@
 ---
 -->
 
-## 2020-12-16, v2.2.2
+## 2020-12-19, v2.3.0
+
+### Notable changes
+
+  - Updated k3s uninstall scripts #74
+  - Started moving Rancher references to `vars/` as per #73
+
+---
+
+## 2020-12-19, v2.2.2
 
 ### Notable changes
 

--- a/tasks/build/configure-k3s-cluster.yml
+++ b/tasks/build/configure-k3s-cluster.yml
@@ -2,7 +2,7 @@
 
 - name: Ensure NODE_TOKEN is captured from control node
   ansible.builtin.slurp:
-    path: "{{ k3s_runtime_config['data-dir'] | default ('/var/lib/rancher/k3s') }}/server/node-token"
+    path: "{{ k3s_runtime_config['data-dir'] | default(k3s_data_dir) }}/server/node-token"
   register: k3s_slurped_control_token
   delegate_to: "{{ k3s_control_delegate }}"
   when: k3s_control_token is not defined and not ansible_check_mode

--- a/tasks/build/install-k3s.yml
+++ b/tasks/build/install-k3s.yml
@@ -16,13 +16,13 @@
 
 - name: Ensure data directory exists when not using the default
   ansible.builtin.file:
-    path: "{{ k3s_runtime_config['data-dir'] | default('/var/lib/rancher/k3s') }}"
+    path: "{{ k3s_runtime_config['data-dir'] | default(k3s_data_dir) }}"
     state: directory
     mode: 0755
   become: "{{ k3s_become_for_data_dir | ternary(true, false, k3s_become_for_all) }}"
   when: k3s_runtime_config is defined
         and "data-dir" in k3s_runtime_config
-        and k3s_runtime_config['data-dir'] != "/var/lib/rancher/k3s"
+        and k3s_runtime_config['data-dir'] != k3s_data_dir
 
 - include_tasks: install-k3s-node.yml
   when: ((k3s_control_node and k3s_controller_count | length == 1)

--- a/templates/k3s-killall.sh.j2
+++ b/templates/k3s-killall.sh.j2
@@ -2,18 +2,18 @@
 
 [ $(id -u) -eq 0 ] || exec sudo $0 $@
 
-for bin in {{ k3s_runtime_config['data-dir'] | default('/var/lib/rancher/k3s') }}/data/**/bin/; do
-    [ -d "$bin" ] && export PATH=$bin:$PATH
+for bin in {{ k3s_runtime_config['data-dir'] | default(k3s_data_dir) }}/data/**/bin/; do
+    [ -d $bin ] && export PATH=$PATH:$bin:$bin/aux
 done
 
 set -x
 
-for service in /etc/systemd/system/k3s*.service; do
-    [ -s "$service" ] && systemctl stop "$(basename $service)"
+for service in {{ k3s_systemd_unit_dir }}/k3s*.service; do
+    [ -s $service ] && systemctl stop $(basename $service)
 done
 
 for service in /etc/init.d/k3s*; do
-    [ -x "$service" ] && "$service" stop
+    [ -x $service ] && $service stop
 done
 
 pschildren() {
@@ -41,38 +41,29 @@ killtree() {
 }
 
 getshims() {
-    lsof | sed -e 's/^[^0-9]*//g; s/  */\t/g' | grep -w 'k3s/data/[^/]*/bin/containerd-shim' | cut -f1 | sort -n -u
+    ps -e -o pid= -o args= | sed -e 's/^ *//; s/\s\s*/\t/;' | grep -w 'k3s/data/[^/]*/bin/containerd-shim' | cut -f1
 }
 
 killtree $({ set +x; } 2>/dev/null; getshims; set -x)
 
-do_unmount() {
-    { set +x; } 2>/dev/null
-    MOUNTS=
-    while read ignore mount ignore; do
-        MOUNTS="$mount\n$MOUNTS"
-    done </proc/self/mounts
-    MOUNTS=$(printf $MOUNTS | grep "^$1" | sort -r)
-    if [ -n "${MOUNTS}" ]; then
-        set -x
-        umount ${MOUNTS}
-    else
-        set -x
-    fi
+do_unmount_and_remove() {
+    awk -v path="$1" '$2 ~ ("^" path) { print $2 }' /proc/self/mounts | sort -r | xargs -r -t -n 1 sh -c 'umount "$0" && rm -rf "$0"'
 }
 
-do_unmount '/run/k3s'
-do_unmount '{{ k3s_runtime_config['data-dir'] | default('/var/lib/rancher/k3s') }}'
-do_unmount '/var/lib/kubelet/pods'
-do_unmount '/run/netns/cni-'
+do_unmount_and_remove '/run/k3s'
+do_unmount_and_remove '{{ k3s_runtime_config['data-dir'] | default(k3s_data_dir) }}'
+do_unmount_and_remove '/var/lib/kubelet/pods'
+do_unmount_and_remove '/run/netns/cni-'
+
+# Remove CNI namespaces
+ip netns show 2>/dev/null | grep cni- | xargs -r -t -n 1 ip netns delete
 
 # Delete network interface(s) that match 'master cni0'
 ip link show 2>/dev/null | grep 'master cni0' | while read ignore iface ignore; do
     iface=${iface%%@*}
     [ -z "$iface" ] || ip link delete $iface
 done
-
 ip link delete cni0
 ip link delete flannel.1
-[ -d /var/lib/cni ] && rm -rf /var/lib/cni/
+rm -rf /var/lib/cni/
 iptables-save | grep -v KUBE- | grep -v CNI- | iptables-restore

--- a/templates/k3s-uninstall.sh.j2
+++ b/templates/k3s-uninstall.sh.j2
@@ -1,61 +1,50 @@
-#!/usr/bin/env bash
+#!/bin/sh
+set -x
+[ $(id -u) -eq 0 ] || exec sudo $0 $@
 
-set -xeuo pipefail
+/usr/local/bin/k3s-killall.sh
 
-[[ "$(id -u)" -eq 0 ]] || exec sudo "${0}" "${@}"
-
-remove_uninstall() {
-    [ -f "${0}" ] && rm -- "${0}"
-    exit 0
-}
-trap remove_uninstall EXIT
-
-/usr/local/bin/k3s-killall.sh ; echo "k3s-killall.sh exited ${?} ..."
-
-WSYSCTL=$(which systemctl || true)
-
-if [[ "${WSYSCTL}" != "" ]] ; then
+if which systemctl; then
     systemctl disable k3s
     systemctl reset-failed k3s
     systemctl daemon-reload
 fi
-
-WRCUPD=$(which rc-update || true)
-
-if [[ "${WRCUPD}" != "" ]] ; then
+if which rc-update; then
     rc-update delete k3s default
 fi
 
-K3SSVC=$(ls /etc/systemd/system/k3s*.service || true)
+rm -f {{ k3s_systemd_unit_dir }}/k3s.service
 
-if [[ "${K3SSVC}" != "" ]] ; then
-    for unit in /etc/systemd/system/k3s*.service ; do
-        unit_name="$(basename "${unit}")"
-        systemctl stop "${unit_name}"
-        [ -f "${unit}" ] && rm -f "${unit}"
-    done
-    systemctl daemon-reload
-fi
+remove_uninstall() {
+    rm -f /usr/local/bin/k3s-uninstall.sh
+}
+trap remove_uninstall EXIT
 
-K3SINIT=$(ls /etc/init.d/k3s* || true)
-
-if [[ "${K3SINIT}" != "" ]] ; then
+if (ls {{ k3s_systemd_unit_dir }}/k3s*.service || ls /etc/init.d/k3s*) >/dev/null 2>&1; then
     set +x; echo 'Additional k3s services installed, skipping uninstall of k3s'; set -x
     exit
 fi
 
-for cmd in {kubectl,crictl,ctr} ; do
-    if [ -f "{{ k3s_install_dir }}/${cmd}" ]; then
-        rm -f "{{ k3s_install_dir }}/${cmd}"
+for cmd in kubectl crictl ctr; do
+    if [ -L {{ k3s_install_dir }}/$cmd ]; then
+        rm -f {{ k3s_install_dir }}/$cmd
     fi
 done
 
 for bin in {{ k3s_install_dir }}/k3s*; do
-    [ -f "${bin}" ] && rm -f "${bin}"
+    if [ -f "${bin}" ]; then
+        rm -f "${bin}"
+    fi
 done
 
-[ -d /etc/rancher/k3s ] && rm -rf /etc/rancher/k3s
-[ -d {{ k3s_runtime_config['data-dir'] | default('/var/lib/rancher/k3s') }} ] && rm -rf {{ k3s_runtime_config['data-dir'] | default('/var/lib/rancher/k3s') }}
-[ -d /var/lib/kubelet ] && rm -rf /var/lib/kubelet
+rm -rf {{ k3s_config_file | dirname }}
+rm -rf /run/k3s
+rm -rf /run/flannel
+rm -rf {{ k3s_runtime_config['data-dir'] | default(k3s_data_dir) }}
+rm -rf /var/lib/kubelet
+rm -f /usr/local/bin/k3s-killall.sh
 
-[ -f /usr/local/bin/k3s-killall.sh ] && rm -f /usr/local/bin/k3s-killall.sh
+if type yum >/dev/null 2>&1; then
+    yum remove -y k3s-selinux
+    rm -f /etc/yum.repos.d/rancher-k3s-common*.repo
+fi

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -65,9 +65,12 @@ k3s_systemd_unit_dir: "/etc/systemd/{{ k3s_systemd_context }}"
 # Directory for gathering the k3s token for clustering. I don't see this changing.
 k3s_token_location: "/etc/rancher/cluster-token"
 
+# Data directory location for k3s
+k3s_data_dir: /var/lib/rancher/k3s
+
 # Path for additional Kubernetes Manifests
 # https://rancher.com/docs/k3s/latest/en/advanced/#auto-deploying-manifests
-k3s_server_manifests_dir: /var/lib/rancher/k3s/server/manifests
+k3s_server_manifests_dir: "{{ k3s_data_dir }}/server/manifests"
 
 # Config items that should not appear in k3s_server or k3s_agent
 k3s_config_exclude:


### PR DESCRIPTION
## Uninstall scripts now in-line with upstream

### Summary

  - Updated k3s uninstall scripts #74
  - Started moving Rancher references to `vars/` as per #73

### Issue type

- Feature

### Test instructions

  1. `molecule converge`
  2.  `molecule login --host node3`
  3. `k3s-uninstall.sh ; echo $?` - Expect the last line to be '0'
  4. `logout`
  5.  `molecule login --host node2`
  6. `k3s-killall.sh ; echo $?` - Expect the last line to be '0'
  7. `logout`
  8. `molecule destroy`

### Acceptance Criteria

  - [x] GitHub Actions Build passes.
  - [x] Molecule uninstall test passes

