### PR TITLE
Added support for armv6l (RPi ZeroW)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,15 @@
 ---
 -->
 
+## 2021-01-02, v2.4.1
+
+### Notable changes
+
+  - Fixed issue with armv6l (Raspberry Pi Zero W)
+  - Added path for private repositories config to directory creation list.
+
+---
+
 ## 2020-12-21, v2.4.0
 
 ### Notable changes

--- a/molecule/requirements.txt
+++ b/molecule/requirements.txt
@@ -1,6 +1,6 @@
 -r ../requirements.txt
 
-molecule[docker]<3.2
+molecule[docker]>=3.2.1
 docker>=4.3.1
 yamllint>=1.25.0
 ansible-lint>=4.3.5

--- a/tasks/build/install-k3s-directories.yml
+++ b/tasks/build/install-k3s-directories.yml
@@ -7,4 +7,5 @@
     mode: "{{ directory.mode | default(0755) }}"
   become: "{{ k3s_become_for_directory_creation | ternary(true, false, k3s_become_for_all) }}"
   when: directory.path is defined
+        and directory.path | length > 0
         and directory.path != omit

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -31,6 +31,12 @@ k3s_arch_lookup:
   arm:
     arch: arm
     suffix: "-armhf"
+  arm6l:
+    arch: arm
+    suffix: "-armhf"
+  armv6l:
+    arch: arm
+    suffix: "-armhf"
   arm7:
     arch: arm
     suffix: "-armhf"
@@ -95,6 +101,8 @@ k3s_ensure_directories_exist:
     path: "{{ k3s_data_dir }}"
   - name: Default local storage path
     path: "{{ k3s_runtime_config['default-local-storage-path'] | default(omit) }}"
+  - name: Private registry config file
+    path: "{{ k3s_runtime_config['private-registry'] | default(omit) }}"
 
 # Config items that should not appear in k3s_server or k3s_agent
 k3s_config_exclude:

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -102,7 +102,7 @@ k3s_ensure_directories_exist:
   - name: Default local storage path
     path: "{{ k3s_runtime_config['default-local-storage-path'] | default(omit) }}"
   - name: Private registry config file
-    path: "{{ k3s_runtime_config['private-registry'] | default(omit) }}"
+    path: "{{ (k3s_runtime_config['private-registry'] | default(omit)) | dirname }}"
 
 # Config items that should not appear in k3s_server or k3s_agent
 k3s_config_exclude:


### PR DESCRIPTION
## Added support for armv6l (RPi ZeroW)

### Summary

Issue with execution against Raspberry Pi Zero W running Raspbian Buster

### Issue type

<!-- Pick one below and delete the rest -->
- Bugfix

### Test instructions

<!-- Please provide instructions for testing this PR -->

### Acceptance Criteria

<!-- Please list criteria required to ensure this change has been sufficiently reviewed.  -->

  - [x] GitHub Actions Build passes.

### Additional Information

Failure message:

```text
TASK [k3s : Ensure target host architecture information is set as a fact] ***************************************************************************************************************************
ok: [arm64]
fatal: [armv6l]: FAILED! => {"msg": "The task includes an option with an undefined variable. The error was: 'dict object' has no attribute 'armv6l'\n\nThe error appears to be in '/home/xmanning/git/k3s-at-home/roles/k3s/tasks/build/download-k3s.yml': line 3, column 3, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n\n- name: Ensure target host architecture information is set as a fact\n  ^ here\n"}
```
