### PR TITLE
Fix check nodes ready without flannel

### DIFF
--- a/molecule/nodeploy/k3s_server.yml
+++ b/molecule/nodeploy/k3s_server.yml
@@ -1,6 +1,6 @@
 ---
 
-flannel-backend: 'host-gw'
+flannel-backend: 'none'
 disable-scheduler: true
 disable-cloud-controller: true
 disable-network-policy: true

--- a/tasks/validate/state/nodes.yml
+++ b/tasks/validate/state/nodes.yml
@@ -11,7 +11,7 @@
   retries: 30
   delay: 20
   when: k3s_control_node
-        and (("disable" not in k3s_runtime_config)
-            or ("disable" in k3s_runtime_config and "flannel" not in k3s_runtime_config.disable))
+        and ("flannel-backend" not in k3s_runtime_config
+            or k3s_runtime_config["flannel-backend"] != "none")
         and not ansible_check_mode
   become: "{{ k3s_become_for_kubectl | ternary(true, false, k3s_become_for_all) }}"


### PR DESCRIPTION
Fixes #84

I've simplified the condition:
```
A is False or (A is True and B is True)
==
A is False or B is True  # since after the or, A is known to be not False (i.e. True)
```
You may want to keep the old check in addition to that for backward compatibility (if any).

I've tested that on my setup.