### PR TITLE
systemd unit ordering + documentation

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,4 +1,4 @@
 ---
 
 skip_list:
-    - '106'
+  - role-name

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,19 @@
 ---
 -->
 
+## 2021-02-16, v2.6.0
+
+### Notable changes
+
+  - Tidy up of `when` params and `assert` tasks to be more readable.
+  - Added feature to tweak K3S service dependencies.
+  - Updated documentation:
+    - Node labels and component arguments
+    - systemd config
+    - Use alternate CNI (Calico example)
+
+---
+
 ## 2021-01-31, v2.5.3
 
 ### Notable changes

--- a/README.md
+++ b/README.md
@@ -71,12 +71,28 @@ consistency. These are generally cluster-level configuration.
 | `k3s_github_url`                 | Set the GitHub URL to install k3s from.                                         | https://github.com/k3s-io/k3s  |
 | `k3s_install_dir`                | Installation directory for k3s.                                                 | `/usr/local/bin`               |
 | `k3s_install_hard_links`         | Install using hard links rather than symbolic links.                            | `false`                        |
-| `k3s_start_on_boot`              | Start k3s on boot.                                                              | `true`                         |
 | `k3s_server_manifests_templates` | A list of Auto-Deploying Manifests Templates.                                   | []                             |
 | `k3s_use_experimental`           | Allow the use of experimental features in k3s.                                  | `false`                        |
 | `k3s_use_unsupported_config`     | Allow the use of unsupported configurations in k3s.                             | `false`                        |
 | `k3s_etcd_datastore`             | Enable etcd embedded datastore (read notes below).                              | `false`                        |
 | `k3s_debug`                      | Enable debug logging on the k3s service.                                        | `false`                        |
+
+### K3S Service Configuration
+
+The below variables change how and when the systemd service unit file for K3S
+is run. Use this with caution, please refer to the [systemd documentation](https://www.freedesktop.org/software/systemd/man/systemd.unit.html#%5BUnit%5D%20Section%20Options)
+for more information.
+
+| Variable               | Description                                                    | Default Value |
+|------------------------|----------------------------------------------------------------|---------------|
+| `k3s_start_on_boot`    | Start k3s on boot.                                             | `true`        |
+| `k3s_service_requires` | List of required systemd units to k3s service unit.            | []            |
+| `k3s_service_wants`    | List of "wanted" systemd unit to k3s (weaker than "requires"). | []\*          |
+| `k3s_service_before`   | Start k3s before a defined list of systemd units.              | []            |
+| `k3s_service_after`    | Start k3s after a defined list of systemd units.               | []\*          |
+
+\* The systemd unit template **always** specifies `network-online.target` for
+`wants` and `after`.
 
 ### Group/Host Variables
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -35,9 +35,6 @@ k3s_install_dir: /usr/local/bin
 # Install using hard links rather than symbolic links
 k3s_install_hard_links: false
 
-# Start k3s on system boot
-k3s_start_on_boot: true
-
 # A list of templates used for preconfigure the cluster.
 k3s_server_manifests_templates: []
 
@@ -50,6 +47,24 @@ k3s_use_unsupported_config: false
 # Enable etcd embedded datastore
 k3s_etcd_datastore: false
 
+##
+# Systemd config
+##
+
+# Start k3s on system boot
+k3s_start_on_boot: true
+
+# List of required systemd units to k3s service unit.
+k3s_service_requires: []
+
+# List of "wanted" systemd unit to k3s (weaker than "requires").
+k3s_service_wants: []
+
+# Start k3s before a defined list of systemd units.
+k3s_service_before: []
+
+# Start k3s after a defined list of systemd units.
+k3s_service_after: []
 
 ##
 # Server Configuration

--- a/documentation/README.md
+++ b/documentation/README.md
@@ -31,6 +31,8 @@ minimum configuration.
 
   - [Setting up 2-node HA control plane with external datastore](configuration/2-node-ha-ext-datastore.md)
   - [Provision multiple standalone k3s nodes](configuration/multiple-standalone-k3s-nodes.md)
+  - [Set node labels and component arguments](configuration/node-labels-and-component-args.md)
+  - [Use an alternate CNI](configuration/use-an-alternate-cni.md)
 
 ### Operations
 

--- a/documentation/README.md
+++ b/documentation/README.md
@@ -33,6 +33,7 @@ minimum configuration.
   - [Provision multiple standalone k3s nodes](configuration/multiple-standalone-k3s-nodes.md)
   - [Set node labels and component arguments](configuration/node-labels-and-component-args.md)
   - [Use an alternate CNI](configuration/use-an-alternate-cni.md)
+  - [Start K3S after another service](configuration/systemd-config.md)
 
 ### Operations
 

--- a/documentation/configuration/2-node-ha-ext-datastore.md
+++ b/documentation/configuration/2-node-ha-ext-datastore.md
@@ -64,6 +64,8 @@ https://rancher.com/docs/k3s/latest/en/installation/datastore/#datastore-endpoin
 
 k3s_server:
   datastore-endpoint: postgres://postgres:verybadpass@database:5432/postgres?sslmode=disable
+  node-taint:
+    - "k3s-controlplane=true:NoExecute"
 ```
 
 Your worker nodes need to know how to connect to the control plane, this is

--- a/documentation/configuration/node-labels-and-component-args.md
+++ b/documentation/configuration/node-labels-and-component-args.md
@@ -1,0 +1,39 @@
+# Configure node labels and component arguments
+
+The following command line arguments can be specified multiple times with
+`key=value` pairs:
+
+  - `--kube-kubelet-arg`
+  - `--kube-proxy-arg`
+  - `--kube-apiserver-arg`
+  - `--kube-scheduler-arg`
+  - `--kube-controller-manager-arg`
+  - `--kube-cloud-controller-manager-arg`
+  - `--node-label`
+  - `--node-taint`
+
+In the config file, this is done by defining a list of values for each
+command like argument, for example:
+
+```yaml
+---
+
+k3s_server:
+  # Set the plugins registry directory
+  kubelet-arg:
+    - "volume-plugin-dir=/var/lib/rancher/k3s/agent/kubelet/plugins_registry"
+  # Set the pod eviction timeout and node monitor grace period
+  kube-controller-manager-arg:
+    - "pod-eviction-timeout=2m"
+    - "node-monitor-grace-period=30s"
+  # Set API server feature gate
+  kube-apiserver-arg:
+    - "feature-gates=RemoveSelfLink=false"
+  # Laels to apply to a node
+  node-label:
+    - "NodeTier=development"
+    - "NodeLocation=eu-west-2a"
+  # Stop k3s control plane having workloads scheduled on them
+  node-taint:
+    - "k3s-controlplane=true:NoExecute"
+```

--- a/documentation/configuration/systemd-config.md
+++ b/documentation/configuration/systemd-config.md
@@ -1,0 +1,19 @@
+# systemd config
+
+Below are examples to tweak how and when K3S starts up.
+
+## Wanted service units
+
+In this example, we're going to start K3S after Wireguard. Our example server
+has a Wireguard connection `wg0`. We are using "wants" rather than "requires"
+as it's a weaker requirement that Wireguard must be running. We then want
+K3S to start after Wireguard has started.
+
+```yaml
+---
+
+k3s_service_wants:
+  - wg-quick@wg0.service
+k3s_service_after:
+  - wg-quick@wg0.service
+```

--- a/documentation/configuration/use-an-alternate-cni.md
+++ b/documentation/configuration/use-an-alternate-cni.md
@@ -1,0 +1,63 @@
+# Use an alternate CNI
+
+K3S ships with Flannel, however sometimes you want an different CNI such as
+Calico, Canal or Weave Net. To do this you will need to disable Flannel with
+`flannel-backend: "none"`, specify a `cluster-cidr` and add your CNI manifests
+to the `k3s_server_manifests_templates`.
+
+## Calico example
+
+The below is based on the
+[Calico quickstart documentation](https://docs.projectcalico.org/getting-started/kubernetes/quickstart).
+
+Steps:
+
+  1. Download `tigera-operator.yaml` to the manifests directory.
+  1. Download `custom-resources.yaml` to the manifests directory.
+  1. Choose a `cluster-cidr` (we are using 192.168.0.0/16)
+  1. Set `k3s_server` and `k3s_server_manifest_templates` as per the below,
+     ensure the paths to manifests are correct for your project repo.
+
+```yaml
+---
+
+# K3S Server config, don't deploy flannel and set cluster pod CIDR.
+k3s_server:
+  cluster-cidr: 192.168.0.0/16
+  flannel-backend: "none"
+
+# Deploy the following k3s server templates.
+k3s_server_manifests_templates:
+  - "manifests/calico/tigera-operator.yaml"
+  - "manifests/calico/custom-resources.yaml"
+```
+
+All nodes should come up as "Ready", below is a 3-node cluster:
+
+```text
+ $ kubectl get nodes -o wide -w
+NAME     STATUS   ROLES                       AGE    VERSION        INTERNAL-IP   EXTERNAL-IP   OS-IMAGE             KERNEL-VERSION     CONTAINER-RUNTIME
+kube-0   Ready    control-plane,etcd,master   114s   v1.20.2+k3s1   10.10.9.2     10.10.9.2     Ubuntu 20.04.1 LTS   5.4.0-56-generic   containerd://1.4.3-k3s1
+kube-1   Ready    control-plane,etcd,master   80s    v1.20.2+k3s1   10.10.9.3     10.10.9.3     Ubuntu 20.04.1 LTS   5.4.0-56-generic   containerd://1.4.3-k3s1
+kube-2   Ready    control-plane,etcd,master   73s    v1.20.2+k3s1   10.10.9.4     10.10.9.4     Ubuntu 20.04.1 LTS   5.4.0-56-generic   containerd://1.4.3-k3s1
+```
+
+Pods should be deployed with deployed within the CIDR specified in our config
+file.
+
+```text
+$ kubectl get pods -o wide -A
+NAMESPACE         NAME                                      READY   STATUS      RESTARTS   AGE     IP               NODE     NOMINATED NODE   READINESS GATES
+calico-system     calico-kube-controllers-cfb4ff54b-8rp8r   1/1     Running     0          5m4s    192.168.145.65   kube-0   <none>           <none>
+calico-system     calico-node-2cm2m                         1/1     Running     0          5m4s    10.10.9.2        kube-0   <none>           <none>
+calico-system     calico-node-2s6lx                         1/1     Running     0          4m42s   10.10.9.4        kube-2   <none>           <none>
+calico-system     calico-node-zwqjz                         1/1     Running     0          4m49s   10.10.9.3        kube-1   <none>           <none>
+calico-system     calico-typha-7b6747d665-78swq             1/1     Running     0          3m5s    10.10.9.4        kube-2   <none>           <none>
+calico-system     calico-typha-7b6747d665-8ff66             1/1     Running     0          3m5s    10.10.9.3        kube-1   <none>           <none>
+calico-system     calico-typha-7b6747d665-hgplx             1/1     Running     0          5m5s    10.10.9.2        kube-0   <none>           <none>
+kube-system       coredns-854c77959c-6qhgt                  1/1     Running     0          5m20s   192.168.145.66   kube-0   <none>           <none>
+kube-system       helm-install-traefik-4czr9                0/1     Completed   0          5m20s   192.168.145.67   kube-0   <none>           <none>
+kube-system       metrics-server-86cbb8457f-qcxf5           1/1     Running     0          5m20s   192.168.145.68   kube-0   <none>           <none>
+kube-system       traefik-6f9cbd9bd4-7h4rl                  1/1     Running     0          2m50s   192.168.126.65   kube-1   <none>           <none>
+tigera-operator   tigera-operator-b6c4bfdd9-29hhr           1/1     Running     0          5m20s   10.10.9.2        kube-0   <none>           <none>
+```

--- a/documentation/quickstart-cluster.md
+++ b/documentation/quickstart-cluster.md
@@ -86,7 +86,7 @@ Here is our playbook for the k3s cluster (`cluster.yml`):
   vars:
     k3s_become_for_all: true
   roles:
-    - xanmanning.k3s
+    - role: xanmanning.k3s
 ```
 
 ## Execution

--- a/documentation/quickstart-ha-cluster.md
+++ b/documentation/quickstart-ha-cluster.md
@@ -94,7 +94,7 @@ Here is our playbook for the k3s cluster (`ha_cluster.yml`):
     k3s_etcd_datastore: true
     k3s_use_experimental: true  # Note this is required for k3s < v1.19.5+k3s1
   roles:
-    - xanmanning.k3s
+    - role: xanmanning.k3s
 ```
 
 ## Execution

--- a/documentation/quickstart-single-node.md
+++ b/documentation/quickstart-single-node.md
@@ -68,7 +68,7 @@ Here is our playbook for a single node k3s cluster (`single_node.yml`):
   vars:
     k3s_become_for_all: true
   roles:
-    - xanmanning.k3s
+    - role: xanmanning.k3s
 ```
 
 ## Execution

--- a/molecule/autodeploy/converge.yml
+++ b/molecule/autodeploy/converge.yml
@@ -13,4 +13,4 @@
     k3s_server_manifests_templates:
       - "molecule/autodeploy/templates/00-ns-monitoring.yml.j2"
   roles:
-    - role: xanmanning.k3s
+    - role: "{{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY') | basename }}"

--- a/molecule/autodeploy/molecule.yml
+++ b/molecule/autodeploy/molecule.yml
@@ -7,7 +7,7 @@ driver:
 lint: |
   set -e
   yamllint -s .
-  ansible-lint
+  ansible-lint --exclude molecule/
 platforms:
   - name: node1
     image: "geerlingguy/docker-${MOLECULE_DISTRO:-centos8}-ansible:latest"

--- a/molecule/debug/molecule.yml
+++ b/molecule/debug/molecule.yml
@@ -7,7 +7,7 @@ driver:
 lint: |
   set -e
   yamllint -s .
-  ansible-lint
+  ansible-lint --exclude molecule/
 platforms:
   - name: node1
     image: "geerlingguy/docker-${MOLECULE_DISTRO:-centos8}-ansible:latest"

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -6,4 +6,4 @@
     molecule_is_test: true
     k3s_install_hard_links: true
   roles:
-    - role: xanmanning.k3s
+    - role: "{{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY') | basename }}"

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -7,7 +7,7 @@ driver:
 lint: |
   set -e
   yamllint -s .
-  ansible-lint
+  ansible-lint --exclude molecule/
 platforms:
   - name: node1
     image: "geerlingguy/docker-${MOLECULE_DISTRO:-centos8}-ansible:latest"

--- a/molecule/default/playbook-download.yml
+++ b/molecule/default/playbook-download.yml
@@ -6,4 +6,4 @@
     molecule_is_test: true
     k3s_state: downloaded
   roles:
-    - role: xanmanning.k3s
+    - role: "{{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY') | basename }}"

--- a/molecule/default/playbook-restart-cluster.yml
+++ b/molecule/default/playbook-restart-cluster.yml
@@ -6,4 +6,4 @@
     molecule_is_test: true
     k3s_state: restarted
   roles:
-    - role: xanmanning.k3s
+    - role: "{{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY') | basename }}"

--- a/molecule/default/playbook-rootless.yml
+++ b/molecule/default/playbook-rootless.yml
@@ -12,4 +12,4 @@
       rootless: true
     k3s_install_dir: "/home/{{ ansible_user_id }}/bin"
   roles:
-    - role: xanmanning.k3s
+    - role: "{{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY') | basename }}"

--- a/molecule/default/playbook-standalone.yml
+++ b/molecule/default/playbook-standalone.yml
@@ -6,4 +6,4 @@
     molecule_is_test: true
     k3s_build_cluster: false
   roles:
-    - role: xanmanning.k3s
+    - role: "{{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY') | basename }}"

--- a/molecule/default/playbook-start-cluster.yml
+++ b/molecule/default/playbook-start-cluster.yml
@@ -6,4 +6,4 @@
     molecule_is_test: true
     k3s_state: started
   roles:
-    - role: xanmanning.k3s
+    - role: "{{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY') | basename }}"

--- a/molecule/default/playbook-stop-cluster.yml
+++ b/molecule/default/playbook-stop-cluster.yml
@@ -6,4 +6,4 @@
     molecule_is_test: true
     k3s_state: stopped
   roles:
-    - role: xanmanning.k3s
+    - role: "{{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY') | basename }}"

--- a/molecule/default/playbook-uninstall-cluster.yml
+++ b/molecule/default/playbook-uninstall-cluster.yml
@@ -6,4 +6,4 @@
     molecule_is_test: true
     k3s_state: uninstalled
   roles:
-    - role: xanmanning.k3s
+    - role: "{{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY') | basename }}"

--- a/molecule/docker/converge.yml
+++ b/molecule/docker/converge.yml
@@ -10,4 +10,4 @@
     k3s_agent:
       docker: true
   roles:
-    - role: xanmanning.k3s
+    - role: "{{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY') | basename }}"

--- a/molecule/docker/molecule.yml
+++ b/molecule/docker/molecule.yml
@@ -7,7 +7,7 @@ driver:
 lint: |
   set -e
   yamllint -s .
-  ansible-lint
+  ansible-lint --exclude molecule/
 platforms:
   - name: node1
     image: "${MOLECULE_DISTRO:-geerlingguy/docker-ubuntu2004-ansible:latest}"

--- a/molecule/highavailabilitydb/converge.yml
+++ b/molecule/highavailabilitydb/converge.yml
@@ -14,4 +14,4 @@
         k3s_control_node: true
       when: inventory_hostname in ['node2', 'node3']
   roles:
-    - role: xanmanning.k3s
+    - role: "{{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY') | basename }}"

--- a/molecule/highavailabilitydb/molecule.yml
+++ b/molecule/highavailabilitydb/molecule.yml
@@ -7,7 +7,7 @@ driver:
 lint: |
   set -e
   yamllint -s .
-  ansible-lint
+  ansible-lint --exclude molecule/
 platforms:
   - name: node1
     image: "geerlingguy/docker-${MOLECULE_DISTRO:-centos8}-ansible:latest"

--- a/molecule/highavailabilityetcd/converge.yml
+++ b/molecule/highavailabilityetcd/converge.yml
@@ -14,4 +14,4 @@
       ansible.builtin.set_fact:
         k3s_control_node: true
   roles:
-    - role: xanmanning.k3s
+    - role: "{{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY') | basename }}"

--- a/molecule/highavailabilityetcd/molecule.yml
+++ b/molecule/highavailabilityetcd/molecule.yml
@@ -7,7 +7,7 @@ driver:
 lint: |
   set -e
   yamllint -s .
-  ansible-lint
+  ansible-lint --exclude molecule/
 platforms:
   - name: node1
     image: "geerlingguy/docker-${MOLECULE_DISTRO:-centos8}-ansible:latest"

--- a/molecule/nodeploy/converge.yml
+++ b/molecule/nodeploy/converge.yml
@@ -7,4 +7,4 @@
     k3s_server: "{{ lookup('file', 'k3s_server.yml') | from_yaml }}"
     k3s_agent: "{{ lookup('file', 'k3s_agent.yml') | from_yaml }}"
   roles:
-    - role: xanmanning.k3s
+    - role: "{{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY') | basename }}"

--- a/molecule/nodeploy/molecule.yml
+++ b/molecule/nodeploy/molecule.yml
@@ -7,7 +7,7 @@ driver:
 lint: |
   set -e
   yamllint -s .
-  ansible-lint
+  ansible-lint --exclude molecule/
 platforms:
   - name: node1
     image: "geerlingguy/docker-${MOLECULE_DISTRO:-centos8}-ansible:latest"

--- a/tasks/build/configure-k3s-cluster.yml
+++ b/tasks/build/configure-k3s-cluster.yml
@@ -5,7 +5,9 @@
     path: "{{ k3s_runtime_config['data-dir'] | default(k3s_data_dir) }}/server/token"
   register: k3s_slurped_cluster_token
   delegate_to: "{{ k3s_control_delegate }}"
-  when: k3s_control_token is not defined and not ansible_check_mode
+  when:
+    - k3s_control_token is not defined
+    - not ansible_check_mode
   become: "{{ k3s_become_for_kubectl | ternary(true, false, k3s_become_for_all) }}"
 
 - name: Ensure cluster token is formatted correctly for use in templates
@@ -66,7 +68,9 @@
   until: ensure_secondary_controllers_started is succeeded
   retries: "{{ ansible_play_hosts_all | length }}"
   delay: 5
-  when: k3s_control_node and not k3s_primary_control_node
+  when:
+    - k3s_control_node
+    - not k3s_primary_control_node
   become: "{{ k3s_become_for_systemd | ternary(true, false, k3s_become_for_all) }}"
 
 - import_tasks: ../validate/state/control-plane.yml

--- a/tasks/build/docker/redhat/install-prerequisites.yml
+++ b/tasks/build/docker/redhat/install-prerequisites.yml
@@ -40,14 +40,16 @@
     enabled: true
     gpgcheck: true
     state: present
-  when: ansible_distribution | lower not in ['amazon']
-        and k3s_redhat_repo_check.status == 200
+  when:
+    - ansible_distribution | lower not in ['amazon']
+    - k3s_redhat_repo_check.status == 200
   become: "{{ k3s_become_for_package_install | ternary(true, false, k3s_become_for_all) }}"
 
 - name: Ensure Docker repository is installed and configured from file
   ansible.builtin.command: yum-config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
   args:
     creates: /etc/yum.repos.d/docker-ce.repo
-  when: ansible_distribution | lower not in ['amazon']
-        and k3s_redhat_repo_check.status != 200
+  when:
+    - ansible_distribution | lower not in ['amazon']
+    - k3s_redhat_repo_check.status != 200
   become: "{{ k3s_become_for_package_install | ternary(true, false, k3s_become_for_all) }}"

--- a/tasks/build/get-systemd-context.yml
+++ b/tasks/build/get-systemd-context.yml
@@ -4,6 +4,7 @@
   ansible.builtin.set_fact:
     k3s_systemd_context: user
     k3s_systemd_unit_dir: "{{ ansible_user_dir }}/.config/systemd/user"
-  when: k3s_runtime_config is defined
-        and "rootless" in k3s_runtime_config
-        and k3s_runtime_config.rootless
+  when:
+    - k3s_runtime_config is defined
+    - k3s_runtime_config.rootless is defined
+    - k3s_runtime_config.rootless

--- a/tasks/build/get-version.yml
+++ b/tasks/build/get-version.yml
@@ -4,7 +4,9 @@
   ansible.builtin.set_fact:
     k3s_release_version: "{{ k3s_release_channel }}"
   check_mode: false
-  when: k3s_release_version is defined and not k3s_release_version
+  when:
+    - k3s_release_version is defined
+    - not k3s_release_version
 
 - name: Ensure the default release channel is set
   ansible.builtin.set_fact:
@@ -24,5 +26,6 @@
     k3s_release_version: "{{ item.latest }}"
   loop: "{{ k3s_latest_release.json.data }}"
   check_mode: false
-  when: item.name == k3s_release_channel
-        and item.type == "channel"
+  when:
+    - item.name == k3s_release_channel
+    - item.type == "channel"

--- a/tasks/build/install-k3s-directories.yml
+++ b/tasks/build/install-k3s-directories.yml
@@ -6,6 +6,7 @@
     state: directory
     mode: "{{ directory.mode | default(0755) }}"
   become: "{{ k3s_become_for_directory_creation | ternary(true, false, k3s_become_for_all) }}"
-  when: directory.path is defined
-        and directory.path | length > 0
-        and directory.path != omit
+  when:
+    - directory.path is defined
+    - directory.path | length > 0
+    - directory.path != omit

--- a/tasks/build/install-k3s-node.yml
+++ b/tasks/build/install-k3s-node.yml
@@ -43,9 +43,9 @@
     dest: "/usr/local/bin/k3s-killall.sh"
     mode: 0700
   become: "{{ k3s_become_for_usr_local_bin | ternary(true, false, k3s_become_for_all) }}"
-  when: k3s_runtime_config is defined
-        and ("rootless" not in k3s_runtime_config
-             or not k3s_runtime_config.rootless)
+  when:
+    - k3s_runtime_config is defined
+    - ("rootless" not in k3s_runtime_config or not k3s_runtime_config.rootless)
 
 - name: Ensure k3s uninstall script is present
   ansible.builtin.template:
@@ -53,6 +53,6 @@
     dest: "/usr/local/bin/k3s-uninstall.sh"
     mode: 0700
   become: "{{ k3s_become_for_usr_local_bin | ternary(true, false, k3s_become_for_all) }}"
-  when: k3s_runtime_config is defined
-        and ("rootless" not in k3s_runtime_config
-             or not k3s_runtime_config.rootless)
+  when:
+    - k3s_runtime_config is defined
+    - ("rootless" not in k3s_runtime_config or not k3s_runtime_config.rootless)

--- a/tasks/build/install-k3s.yml
+++ b/tasks/build/install-k3s.yml
@@ -6,8 +6,10 @@
     loop_var: directory
 
 - include_tasks: install-k3s-node.yml
-  when: ((k3s_control_node and k3s_controller_list | length == 1)
-        or (k3s_primary_control_node and k3s_controller_list | length > 1)) and not ansible_check_mode
+  when:
+    - ((k3s_control_node and k3s_controller_list | length == 1)
+        or (k3s_primary_control_node and k3s_controller_list | length > 1))
+    - not ansible_check_mode
 
 - meta: flush_handlers
 

--- a/tasks/build/preconfigure-k3s.yml
+++ b/tasks/build/preconfigure-k3s.yml
@@ -3,8 +3,9 @@
 - name: Ensure k3s_build_cluster is false if running against a single node.
   ansible.builtin.set_fact:
     k3s_build_cluster: false
-  when: ansible_play_hosts_all | length < 2
-        and k3s_control_node_address is not defined
+  when:
+    - ansible_play_hosts_all | length < 2
+    - k3s_control_node_address is not defined
 
 - name: Ensure k3s control node fact is set
   ansible.builtin.set_fact:
@@ -24,8 +25,9 @@
 - name: Ensure a count of control nodes is generated
   ansible.builtin.set_fact:
     k3s_controller_list: "{{ k3s_controller_list + [ item ] }}"
-  when: hostvars[item].k3s_control_node is defined
-        and hostvars[item].k3s_control_node
+  when:
+    - hostvars[item].k3s_control_node is defined
+    - hostvars[item].k3s_control_node
   loop: "{{ ansible_play_hosts_all }}"
 
 - name: Ensure a k3s control node is defined if none are found in ansible_play_hosts_all
@@ -39,20 +41,25 @@
     - name: Ensure a count of control nodes is generated
       ansible.builtin.set_fact:
         k3s_controller_list: "{{ k3s_controller_list + [ item ] }}"
-      when: hostvars[item].k3s_control_node is defined
-            and hostvars[item].k3s_control_node
+      when:
+        - hostvars[item].k3s_control_node is defined
+        - hostvars[item].k3s_control_node
       loop: "{{ ansible_play_hosts_all }}"
 
-  when: k3s_controller_list | length < 1
-        and k3s_build_cluster is defined and k3s_build_cluster
+  when:
+    - k3s_controller_list | length < 1
+    - k3s_build_cluster is defined
+    - k3s_build_cluster
 
 - name: Ensure a primary k3s control node is defined if multiple are found in ansible_play_hosts_all
   ansible.builtin.set_fact:
     k3s_primary_control_node: true
-  when: k3s_controller_list is defined
-        and k3s_controller_list | length > 1
-        and inventory_hostname == k3s_controller_list[0]
-        and k3s_build_cluster is defined and k3s_build_cluster
+  when:
+    - k3s_controller_list is defined
+    - k3s_controller_list | length > 1
+    - inventory_hostname == k3s_controller_list[0]
+    - k3s_build_cluster is defined
+    - k3s_build_cluster
 
 - name: Ensure ansible_host is mapped to inventory_hostname
   ansible.builtin.lineinfile:
@@ -98,11 +105,13 @@
 - name: Ensure k3s_runtime_config is set for control plane
   ansible.builtin.set_fact:
     k3s_runtime_config: "{{ (k3s_server | default({})) | combine((k3s_agent | default({}))) }}"
-  when: (k3s_server is defined or k3s_agent is defined)
-        and (k3s_control_node is defined and k3s_control_node)
+  when:
+    - (k3s_server is defined or k3s_agent is defined)
+    - (k3s_control_node is defined and k3s_control_node)
 
 - name: Ensure k3s_runtime_config is set for agents
   ansible.builtin.set_fact:
     k3s_runtime_config: "{{ (k3s_agent | default({})) }}"
-  when: k3s_agent is defined
-        and (k3s_control_node is not defined or not k3s_control_node)
+  when:
+    - k3s_agent is defined
+    - (k3s_control_node is not defined or not k3s_control_node)

--- a/tasks/operate/start-k3s.yml
+++ b/tasks/operate/start-k3s.yml
@@ -14,5 +14,7 @@
     state: started
     enabled: "{{ k3s_start_on_boot }}"
     scope: user
-  when: k3s_non_root is defined and k3s_non_root
+  when:
+    - k3s_non_root is defined
+    - k3s_non_root
   become: "{{ k3s_become_for_systemd | ternary(true, false, k3s_become_for_all) }}"

--- a/tasks/operate/stop-k3s.yml
+++ b/tasks/operate/stop-k3s.yml
@@ -14,5 +14,7 @@
     state: stopped
     enabled: "{{ k3s_start_on_boot }}"
     scope: user
-  when: k3s_non_root is defined and k3s_non_root
+  when:
+    - k3s_non_root is defined
+    - k3s_non_root
   become: "{{ k3s_become_for_systemd | ternary(true, false, k3s_become_for_all) }}"

--- a/tasks/state-installed.yml
+++ b/tasks/state-installed.yml
@@ -25,19 +25,23 @@
     - include_tasks: build/docker/{{ ansible_distribution | replace(" ", "-") | lower }}/install.yml
       when: ansible_distribution | replace(" ", "-") | lower in ['amazon', 'suse', 'opensuse-leap', 'archlinux']
 
-  when: ('docker' in k3s_runtime_config and k3s_runtime_config.docker)
-        and ('rootless' not in k3s_runtime_config or not k3s_runtime_config.rootless)
+  when:
+    - ('docker' in k3s_runtime_config and k3s_runtime_config.docker)
+    - ('rootless' not in k3s_runtime_config or not k3s_runtime_config.rootless)
 
 - meta: flush_handlers
 
 - import_tasks: build/download-k3s.yml
 
 - import_tasks: build/preconfigure-k3s-auto-deploying-manifests.yml
-  when: k3s_control_node
-        and k3s_server_manifests_templates | length > 0
+  when:
+    - k3s_control_node
+    - k3s_server_manifests_templates | length > 0
 
 - import_tasks: build/install-k3s.yml
 
 - import_tasks: build/configure-k3s-cluster.yml
-  when: k3s_build_cluster is defined and k3s_build_cluster
-        and k3s_control_node_address is defined
+  when:
+    - k3s_build_cluster is defined
+    - k3s_build_cluster
+    - k3s_control_node_address is defined

--- a/tasks/state-uninstalled.yml
+++ b/tasks/state-uninstalled.yml
@@ -17,8 +17,9 @@
 
     - include_tasks: teardown/docker/{{ ansible_os_family | lower }}/uninstall-prerequisites.yml
 
-  when: ('docker' in k3s_runtime_config and k3s_runtime_config.docker)
-        and ('rootless' not in k3s_runtime_config or not k3s_runtime_config.rootless)
+  when:
+    - ('docker' in k3s_runtime_config and k3s_runtime_config.docker)
+    - ('rootless' not in k3s_runtime_config or not k3s_runtime_config.rootless)
 
 - import_tasks: validate/state/uninstalled.yml
   when: not k3s_skip_validation

--- a/tasks/teardown/drain-and-remove-nodes.yml
+++ b/tasks/teardown/drain-and-remove-nodes.yml
@@ -22,9 +22,10 @@
       ansible.builtin.command: "{{ k3s_install_dir }}/kubectl drain {{ item }} --ignore-daemonsets --delete-local-data"
       delegate_to: "{{ k3s_control_delegate }}"
       run_once: true
-      when: item in kubectl_get_nodes_result.stdout
-            and hostvars[item].k3s_state is defined
-            and hostvars[item].k3s_state == 'uninstalled'
+      when:
+        - item in kubectl_get_nodes_result.stdout
+        - hostvars[item].k3s_state is defined
+        - hostvars[item].k3s_state == 'uninstalled'
       loop: "{{ ansible_play_hosts_all }}"
       become: "{{ k3s_become_for_kubectl | ternary(true, false, k3s_become_for_all) }}"
 
@@ -32,13 +33,15 @@
       ansible.builtin.command: "{{ k3s_install_dir }}/kubectl delete node {{ item }}"
       delegate_to: "{{ k3s_control_delegate }}"
       run_once: true
-      when: item in kubectl_get_nodes_result.stdout
-            and hostvars[item].k3s_state is defined
-            and hostvars[item].k3s_state == 'uninstalled'
+      when:
+        - item in kubectl_get_nodes_result.stdout
+        - hostvars[item].k3s_state is defined
+        - hostvars[item].k3s_state == 'uninstalled'
       loop: "{{ ansible_play_hosts_all }}"
       become: "{{ k3s_become_for_kubectl | ternary(true, false, k3s_become_for_all) }}"
 
-  when: k3s_check_kubectl.stat.exists is defined
-        and k3s_check_kubectl.stat.exists
-        and k3s_control_delegate is defined
-        and not ansible_check_mode
+  when:
+    - k3s_check_kubectl.stat.exists is defined
+    - k3s_check_kubectl.stat.exists
+    - k3s_control_delegate is defined
+    - not ansible_check_mode

--- a/tasks/teardown/uninstall-k3s.yml
+++ b/tasks/teardown/uninstall-k3s.yml
@@ -40,11 +40,13 @@
     - kubectl
     - crictl
     - ctr
-  when: k3s_install_hard_links
-        and not ansible_check_mode
+  when:
+    - k3s_install_hard_links
+    - not ansible_check_mode
   become: "{{ k3s_become_for_uninstall | ternary(true, false, k3s_become_for_all) }}"
 
 - name: Clean up Docker
   ansible.builtin.command: docker system prune -a --force
-  when: ("docker" in k3s_runtime_config and k3s_runtime_config.docker)
-        and check_k3s_docker_path.rc == 0
+  when:
+    - ("docker" in k3s_runtime_config and k3s_runtime_config.docker)
+    - check_k3s_docker_path.rc == 0

--- a/tasks/validate/configuration/control-node-count.yml
+++ b/tasks/validate/configuration/control-node-count.yml
@@ -4,33 +4,36 @@
   ansible.builtin.assert:
     that:
       - (k3s_controller_list | length == 1)
-        and ("datastore-endpoint" not in k3s_runtime_config or not k3s_runtime_config['datastore-endpoint'])
-        and (k3s_etcd_datastore is not defined or not k3s_etcd_datastore)
+      - ("datastore-endpoint" not in k3s_runtime_config or not k3s_runtime_config['datastore-endpoint'])
+      - (k3s_etcd_datastore is not defined or not k3s_etcd_datastore)
     success_msg: "Control plane configuration is valid."
     fail_msg: "Control plane configuration is invalid. Please see notes about k3s_control_node and HA in README.md."
-  when: k3s_controller_list | length == 1
-        and not k3s_use_unsupported_config
-        and k3s_control_node
+  when:
+    - k3s_controller_list | length == 1
+    - not k3s_use_unsupported_config
+    - k3s_control_node
 
 - name: Check the conditions when multiple controllers are defined
   ansible.builtin.assert:
     that:
       - (k3s_controller_list | length >= 2)
-        and (("datastore-endpoint" in k3s_runtime_config and k3s_runtime_config['datastore-endpoint'])
-            or (k3s_etcd_datastore is defined and k3s_etcd_datastore))
+      - (("datastore-endpoint" in k3s_runtime_config and k3s_runtime_config['datastore-endpoint'])
+          or (k3s_etcd_datastore is defined and k3s_etcd_datastore))
     success_msg: "Control plane configuration is valid."
     fail_msg: "Control plane configuration is invalid. Please see notes about k3s_control_node and HA in README.md."
-  when: k3s_controller_list | length >= 2
-        and k3s_control_node
+  when:
+    - k3s_controller_list | length >= 2
+    - k3s_control_node
 
 - name: Check the conditions when embedded etcd is defined
   ansible.builtin.assert:
     that:
       - (k3s_controller_list | length >= 3)
-        and (((k3s_controller_list | length) % 2) == 1)
+      - (((k3s_controller_list | length) % 2) == 1)
     success_msg: "Control plane configuration is valid."
     fail_msg: "Etcd should have a minimum of 3 defined members and the number of members should be odd. Please see notes about HA in README.md"
-  when: k3s_etcd_datastore is defined
-        and k3s_etcd_datastore
-        and not k3s_use_unsupported_config
-        and k3s_control_node
+  when:
+    - k3s_etcd_datastore is defined
+    - k3s_etcd_datastore
+    - not k3s_use_unsupported_config
+    - k3s_control_node

--- a/tasks/validate/configuration/experimental-variables.yml
+++ b/tasks/validate/configuration/experimental-variables.yml
@@ -8,8 +8,10 @@
     fail_msg: >-
       Experimental variable k3s_etcd_datastore has been configured.
       If you want to use this ensure you set k3s_use_experimental,
-  when: k3s_etcd_datastore is defined and k3s_etcd_datastore
-        and (k3s_release_version | replace('v', '')) is version_compare("1.19.5", '<')
+  when:
+    - k3s_etcd_datastore is defined
+    - k3s_etcd_datastore
+    - (k3s_release_version | replace('v', '')) is version_compare("1.19.5", '<')
 
 - name: Check if any experimental variables are configure and if they are enabled with k3s_use_experimental
   ansible.builtin.assert:
@@ -23,6 +25,7 @@
       Documentation: {{ item.documentation }}
       {% endif %}
   loop: "{{ k3s_experimental_config }}"
-  when: (item.setting in k3s_runtime_config and k3s_runtime_config[item.setting])
-        and ((item.until is not defined) or
-            (item.until is defined and (k3s_release_version | replace('v', '')) is version_compare(item.until, '<')))
+  when:
+    - (item.setting in k3s_runtime_config and k3s_runtime_config[item.setting])
+    - ((item.until is not defined) or
+        (item.until is defined and (k3s_release_version | replace('v', '')) is version_compare(item.until, '<')))

--- a/tasks/validate/configuration/unsupported-rootless.yml
+++ b/tasks/validate/configuration/unsupported-rootless.yml
@@ -57,5 +57,6 @@
       - ansible_env['XDG_RUNTIME_DIR'] is defined
       - k3s_check_newuidmap_installed.rc == 0
     success_msg: All kernel parameters passed
-    fail_msg: Kernel parameters are not set correctly, please check
-              https://github.com/rootless-containers/rootlesskit
+    fail_msg: >-
+      Kernel parameters are not set correctly, please check
+      https://github.com/rootless-containers/rootlesskit

--- a/tasks/validate/configuration/variables.yml
+++ b/tasks/validate/configuration/variables.yml
@@ -33,9 +33,10 @@
       Documentation: {{ item.documentation }}
       {% endif %}
   loop: "{{ k3s_deprecated_config }}"
-  when: (item.when is not defined
-        or (item.when is defined and (k3s_release_version | replace('v', '')) is version_compare(item.when, '>=')))
-        and not k3s_use_unsupported_config
+  when:
+    - (item.when is not defined
+       or (item.when is defined and (k3s_release_version | replace('v', '')) is version_compare(item.when, '>=')))
+    - not k3s_use_unsupported_config
 
 - name: Check configuration in k3s_server and k3s_agent against release version
   ansible.builtin.assert:
@@ -49,5 +50,6 @@
       Documentation: {{ item.documentation }}
       {% endif %}
   loop: "{{ k3s_config_version_check }}"
-  when: k3s_config_version_check is defined
-        and item.setting in k3s_runtime_config
+  when:
+    - k3s_config_version_check is defined
+    - item.setting in k3s_runtime_config

--- a/tasks/validate/environment/local/packages.yml
+++ b/tasks/validate/environment/local/packages.yml
@@ -4,7 +4,9 @@
   ansible.builtin.assert:
     that:
       - ansible_version.string is version_compare(k3s_ansible_min_version, '>=')
-    fail_msg: "Ansible v{{ ansible_version.string }} is not supported by this role. Please install >= v{{ k3s_ansible_min_version }}"
+    fail_msg: >-
+      Ansible v{{ ansible_version.string }} is not supported by this role.
+      Please install >= v{{ k3s_ansible_min_version }}
     success_msg: "Ansible v{{ ansible_version.string }} is supported."
   become: false
   delegate_to: localhost

--- a/tasks/validate/environment/remote/packages.yml
+++ b/tasks/validate/environment/remote/packages.yml
@@ -16,7 +16,8 @@
       {% if package.documentation is defined %}
       Documentation: {{ package.documentation }}
       {% endif %}
-  when: (package.until is not defined
-          or k3s_release_version is version_compare(package.until, '>='))
-        and (package.from is not defined
-            or k3s_release_version is version_compare(package.from, '>='))
+  when:
+    - (package.until is not defined
+       or k3s_release_version is version_compare(package.until, '>='))
+    - (package.from is not defined
+       or k3s_release_version is version_compare(package.from, '>='))

--- a/tasks/validate/main.yml
+++ b/tasks/validate/main.yml
@@ -5,8 +5,11 @@
 - import_tasks: configuration/experimental-variables.yml
 
 - import_tasks: configuration/unsupported-rootless.yml
-  when: ("rootless" in k3s_runtime_config)
-        and k3s_runtime_config.rootless
+  when:
+    - k3s_runtime_config.rootless is defined
+    - k3s_runtime_config.rootless
 
 - import_tasks: configuration/control-node-count.yml
-  when: k3s_build_cluster is defined and k3s_build_cluster
+  when:
+    - k3s_build_cluster is defined
+    - k3s_build_cluster

--- a/tasks/validate/pre-flight.yml
+++ b/tasks/validate/pre-flight.yml
@@ -9,15 +9,19 @@
   when: k3s_state is defined
 
 - import_tasks: environment/local/packages.yml
-  when: not k3s_skip_validation
-        and not k3s_skip_env_checks
+  when:
+    - not k3s_skip_validation
+    - not k3s_skip_env_checks
 
 - include_tasks: environment/remote/packages.yml
   loop: "{{ k3s_check_packages }}"
   loop_control:
     loop_var: package
-  when: not k3s_skip_validation
-        and not k3s_skip_env_checks
+  when:
+    - k3s_skip_validation
+    - not k3s_skip_env_checks
 
 - include_tasks: environment/local/issue-data.yml
-  when: pyratlabs_issue_controller_dump is defined and pyratlabs_issue_controller_dump
+  when:
+    - pyratlabs_issue_controller_dump is defined
+    - pyratlabs_issue_controller_dump

--- a/tasks/validate/state/nodes.yml
+++ b/tasks/validate/state/nodes.yml
@@ -6,12 +6,14 @@
   failed_when: kubectl_get_nodes_result.stdout.find("was refused") != -1 or
                kubectl_get_nodes_result.stdout.find("ServiceUnavailable") != -1
   register: kubectl_get_nodes_result
-  until: kubectl_get_nodes_result.rc == 0
-         and kubectl_get_nodes_result.stdout.find("NotReady") == -1
+  until:
+    - kubectl_get_nodes_result.rc == 0
+    - kubectl_get_nodes_result.stdout.find("NotReady") == -1
   retries: 30
   delay: 20
-  when: k3s_control_node
-        and ("flannel-backend" not in k3s_runtime_config
-            or k3s_runtime_config["flannel-backend"] != "none")
-        and not ansible_check_mode
+  when:
+    - k3s_control_node
+    - ("flannel-backend" not in k3s_runtime_config
+       or k3s_runtime_config["flannel-backend"] != "none")
+    - not ansible_check_mode
   become: "{{ k3s_become_for_kubectl | ternary(true, false, k3s_become_for_all) }}"

--- a/tasks/validate/state/uninstalled.yml
+++ b/tasks/validate/state/uninstalled.yml
@@ -16,12 +16,16 @@
   ignore_errors: true
   changed_when: false
   register: check_k3s_docker_process
-  when: ("docker" in k3s_runtime_config and k3s_runtime_config.docker)
+  when:
+    - k3s_runtime_config.docker is defined
+    - k3s_runtime_config.docker
 
 - name: Fail if docker is still running
   ansible.builtin.fail:
     msg: docker is still running, uninstall script failed. Please investigate.
-  when: ("docker" in k3s_runtime_config and k3s_runtime_config.docker)
+  when:
+    - k3s_runtime_config.docker is defined
+    - k3s_runtime_config.docker
 
 - name: Fail if k3s binaries have not been removed
   ansible.builtin.stat:
@@ -41,7 +45,7 @@
 
 - name: Fail if k3s-killall.sh script still exists
   ansible.builtin.fail:
-    msg: k3s-killall.sh is still running, uninstall script failed. Please investigate.
+    msg: k3s-killall.sh still exists, uninstall script failed. Please investigate.
   when: check_k3s_killall.stat.exists
 
 - name: Check k3s-uninstall.sh is removed
@@ -51,5 +55,5 @@
 
 - name: Fail if k3s-uninstall.sh script still exists
   ansible.builtin.fail:
-    msg: k3s-uninstall.sh is still running, uninstall script failed. Please investigate.
+    msg: k3s-uninstall.sh is still exists, uninstall script failed. Please investigate.
   when: check_k3s_uninstall.stat.exists

--- a/templates/k3s.service.j2
+++ b/templates/k3s.service.j2
@@ -1,8 +1,20 @@
 [Unit]
 Description=Lightweight Kubernetes
 Documentation=https://k3s.io
+{% for requires_unit in k3s_service_requires %}
+Requires={{ requires_unit }}
+{% endfor %}
 Wants=network-online.target
+{% for wants_unit in k3s_service_wants %}
+Wants={{ wants_unit }}
+{% endfor %}
+{% for before_unit in k3s_service_before %}
+Before={{ before_unit }}
+{% endfor %}
 After=network-online.target
+{% for after_unit in k3s_service_after %}
+After={{ after_unit }}
+{% endfor %}
 
 [Service]
 Type={{ 'notify' if k3s_control_node else 'exec' }}


### PR DESCRIPTION
## systemd unit ordering + documentation

### Summary

Adds more documentation, as well as the ability to add dependent systemd units to the k3s service. PR includes a bit of a tidy up of `when` and `assert` .

### Issue type

- Documentation
- Feature

### Test instructions

See Checks

### Acceptance Criteria

  - [x] GitHub Actions Build passes.
  - [x] Documentation updated.

