### PR TITLE
fixed kubectl_get_nodes_result.stdout error

### DIFF
--- a/tasks/teardown/drain-and-remove-nodes.yml
+++ b/tasks/teardown/drain-and-remove-nodes.yml
@@ -29,6 +29,7 @@
       delegate_to: "{{ k3s_control_delegate }}"
       run_once: true
       when:
+        - kubectl_get_nodes_result.stdout is defined
         - item in kubectl_get_nodes_result.stdout
         - hostvars[item].k3s_state is defined
         - hostvars[item].k3s_state == 'uninstalled'
@@ -41,6 +42,7 @@
       delegate_to: "{{ k3s_control_delegate }}"
       run_once: true
       when:
+        - kubectl_get_nodes_result.stdout is defined
         - item in kubectl_get_nodes_result.stdout
         - hostvars[item].k3s_state is defined
         - hostvars[item].k3s_state == 'uninstalled'


### PR DESCRIPTION
os ubuntu  amd64 16.04 LTS
ansible 2.9.20
python version 2.7

```
 FAILED! => {"msg": "The conditional check 'item in kubectl_get_nodes_result.stdout' failed. The error was: error while evaluating conditional (item in kubectl_get_nodes_result.stdout): 'dict object' has no attribute 'stdout'\n\nThe error appears to be in '/home/rancher/.ansible/roles/xanmanning.k3s/tasks/teardown/drain-and-remove-nodes.yml': line 39, column 7, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n\n    - name: Ensure uninstalled nodes are removed\n      ^ here\n"}

```

## TITLE

### Summary

<!-- Describe the change below, including rationale and design decisions -->

<!-- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

### Issue type

<!-- Pick one below and delete the rest -->
- Bugfix
- Documentation
- Feature

### Test instructions

<!-- Please provide instructions for testing this PR -->

### Acceptance Criteria

<!-- Please list criteria required to ensure this change has been sufficiently reviewed.  -->

<!-- Example ticklist:
  - [ ] GitHub Actions Build passes.
  - [ ] Documentation updated.
-->

### Additional Information

<!-- Include additional information to help people understand the change here -->

<!-- Paste verbatim command output below, e.g. before and after your change -->

```text

```
