### PR TITLE
Unmount CSI plugin folder to avoid data lost on uninstall

### DIFF
--- a/templates/k3s-killall.sh.j2
+++ b/templates/k3s-killall.sh.j2
@@ -53,6 +53,7 @@ do_unmount_and_remove() {
 do_unmount_and_remove '/run/k3s'
 do_unmount_and_remove '{{ k3s_runtime_config['data-dir'] | default(k3s_data_dir) }}'
 do_unmount_and_remove '/var/lib/kubelet/pods'
+do_unmount_and_remove '/var/lib/kubelet/plugins'
 do_unmount_and_remove '/run/netns/cni-'
 
 # Remove CNI namespaces


### PR DESCRIPTION
## Unmount CSI plugin folder to avoid data lost on uninstall

### Summary

<!-- Describe the change below, including rationale and design decisions -->

<!-- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
kubelet mounts for CSI pluging are not unmounted in k3s-killall.sh. As result data from CEPH and other CSI pluging is deleted by k3s-uninstall.sh

### Issue type

<!-- Pick one below and delete the rest -->
- Bugfix

### Test instructions

<!-- Please provide instructions for testing this PR -->
1. Install k3s with this ansible role
2. Check that the extra unmount line is present in k3s-killall.sh

### Acceptance Criteria

<!-- Please list criteria required to ensure this change has been sufficiently reviewed.  -->

Fixed upstream - see https://github.com/k3s-io/k3s/issues/3264

### Additional Information

<!-- Include additional information to help people understand the change here -->

<!-- Paste verbatim command output below, e.g. before and after your change -->

```text

```
