### PR TITLE
Support k3s private registry configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ __pycache__
 ansible.cfg
 pyratlabs-issue-dump.txt
 .cache
+/.idea/

--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ consistency. These are generally cluster-level configuration.
 | `k3s_use_unsupported_config`     | Allow the use of unsupported configurations in k3s.                             | `false`                        |
 | `k3s_etcd_datastore`             | Enable etcd embedded datastore (read notes below).                              | `false`                        |
 | `k3s_debug`                      | Enable debug logging on the k3s service.                                        | `false`                        |
+| `k3s_registries`                 | Configuration containerd's registries config file.                              | `mirrors:\n configs:\n`        |
 
 ### K3S Service Configuration
 

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ consistency. These are generally cluster-level configuration.
 | `k3s_use_unsupported_config`     | Allow the use of unsupported configurations in k3s.                             | `false`                        |
 | `k3s_etcd_datastore`             | Enable etcd embedded datastore (read notes below).                              | `false`                        |
 | `k3s_debug`                      | Enable debug logging on the k3s service.                                        | `false`                        |
-| `k3s_registries`                 | Configuration containerd's registries config file.                              | `mirrors:\n configs:\n`        |
+| `k3s_registries`                 | Registries configuration file content.                                          | `{ mirrors: {}, configs:{} }`  |
 
 ### K3S Service Configuration
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -98,9 +98,10 @@ k3s_become_for_package_install: null
 k3s_become_for_kubectl: null
 k3s_become_for_uninstall: null
 
-
+# Private registry configuration.
+# Rancher k3s documentation: https://rancher.com/docs/k3s/latest/en/installation/private-registry/
 k3s_registries:
-# rancher k3s doc https://rancher.com/docs/k3s/latest/en/installation/private-registry/
+
   mirrors:
 #    docker.io:
 #      endpoint:
@@ -108,9 +109,14 @@ k3s_registries:
   configs:
 #    "mycustomreg:5000":
 #      auth:
-#        username: xxxxxx # this is the registry username
-#        password: xxxxxx # this is the registry password
+#        # this is the registry username
+#        username: xxxxxx
+#        # this is the registry password
+#        password: xxxxxx
 #      tls:
-#        cert_file: # path to the cert file used in the registry
-#        key_file:  # path to the key file used in the registry
-#        ca_file:   # path to the ca file used in the registry
+#        # path to the cert file used in the registry
+#        cert_file:
+#        # path to the key file used in the registry
+#        key_file:
+#        # path to the ca file used in the registry
+#        ca_file:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -97,3 +97,20 @@ k3s_become_for_usr_local_bin: null
 k3s_become_for_package_install: null
 k3s_become_for_kubectl: null
 k3s_become_for_uninstall: null
+
+
+k3s_registries:
+# rancher k3s doc https://rancher.com/docs/k3s/latest/en/installation/private-registry/
+  mirrors:
+#    docker.io:
+#      endpoint:
+#        - "https://mycustomreg.com:5000"
+  configs:
+#    "mycustomreg:5000":
+#      auth:
+#        username: xxxxxx # this is the registry username
+#        password: xxxxxx # this is the registry password
+#      tls:
+#        cert_file: # path to the cert file used in the registry
+#        key_file:  # path to the key file used in the registry
+#        ca_file:   # path to the ca file used in the registry

--- a/tasks/build/containerd/registries.yml
+++ b/tasks/build/containerd/registries.yml
@@ -1,0 +1,11 @@
+---
+
+- name: Ensure containerd registries file exists
+  ansible.builtin.template:
+    src: registries.yaml.j2
+    dest: "{{ k3s_config_dir }}/registries.yaml"
+    mode: 0644
+  notify:
+    - reload systemd
+    - restart k3s
+  become: "{{ k3s_become_for_install_dir | ternary(true, false, k3s_become_for_all) }}"

--- a/tasks/build/containerd/registries.yml
+++ b/tasks/build/containerd/registries.yml
@@ -4,7 +4,7 @@
   ansible.builtin.template:
     src: registries.yaml.j2
     dest: "{{ k3s_config_dir }}/registries.yaml"
-    mode: 0644
+    mode: 0600
   notify:
     - reload systemd
     - restart k3s

--- a/tasks/state-installed.yml
+++ b/tasks/state-installed.yml
@@ -29,6 +29,15 @@
     - ('docker' in k3s_runtime_config and k3s_runtime_config.docker)
     - ('rootless' not in k3s_runtime_config or not k3s_runtime_config.rootless)
 
+
+- name: Ensure containerd installation tasks are run
+  block:
+    - include_tasks: build/containerd/registries.yml
+  when:
+    - k3s_registries is defined
+    - (k3s_runtime_config.docker is not defined or not k3s_runtime_config.docker)
+    - ('rootless' not in k3s_runtime_config or not k3s_runtime_config.rootless)
+
 - name: Flush Handlers
   meta: flush_handlers
 

--- a/tasks/state-installed.yml
+++ b/tasks/state-installed.yml
@@ -29,15 +29,6 @@
     - ('docker' in k3s_runtime_config and k3s_runtime_config.docker)
     - ('rootless' not in k3s_runtime_config or not k3s_runtime_config.rootless)
 
-
-- name: Ensure containerd installation tasks are run
-  block:
-    - include_tasks: build/containerd/registries.yml
-  when:
-    - k3s_registries is defined
-    - (k3s_runtime_config.docker is not defined or not k3s_runtime_config.docker)
-    - ('rootless' not in k3s_runtime_config or not k3s_runtime_config.rootless)
-
 - name: Flush Handlers
   meta: flush_handlers
 
@@ -49,6 +40,14 @@
     - k3s_server_manifests_templates | length > 0
 
 - import_tasks: build/install-k3s.yml
+
+- name: Ensure containerd installation tasks are run
+  block:
+    - include_tasks: build/containerd/registries.yml
+  when:
+    - k3s_registries is defined
+    - (k3s_runtime_config.docker is not defined or not k3s_runtime_config.docker)
+    - ('rootless' not in k3s_runtime_config or not k3s_runtime_config.rootless)
 
 - include_tasks: validate/configuration/cluster-init.yml
   when:

--- a/templates/registries.yaml.j2
+++ b/templates/registries.yaml.j2
@@ -1,0 +1,1 @@
+{{ k3s_registries | to_nice_yaml }}

--- a/templates/registries.yaml.j2
+++ b/templates/registries.yaml.j2
@@ -1,1 +1,2 @@
+---
 {{ k3s_registries | to_nice_yaml }}


### PR DESCRIPTION
## Support k3s private registry configuration

### Support k3s private registry configuration

<!-- Describe the change below, including rationale and design decisions -->

<!-- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

### Issue type

<!-- Pick one below and delete the rest -->
- Bugfix
- Documentation rancher k3s doc https://rancher.com/docs/k3s/latest/en/installation/private-registry/
- Feature

### Test instructions

<!-- Please provide instructions for testing this PR -->

### Acceptance Criteria

<!-- Please list criteria required to ensure this change has been sufficiently reviewed.  -->

<!-- Example ticklist:
  - [ ] GitHub Actions Build passes.
  - [ ] Documentation updated.
-->

### Additional Information

<!-- Include additional information to help people understand the change here -->

<!-- Paste verbatim command output below, e.g. before and after your change -->

vars.yml

```yaml
# ....
k3s_registries:
# rancher k3s doc https://rancher.com/docs/k3s/latest/en/installation/private-registry/
  mirrors:
#    docker.io:
#      endpoint:
#        - "https://mycustomreg.com:5000"
  configs:
#    "mycustomreg:5000":
#      auth:
#        username: xxxxxx # this is the registry username
#        password: xxxxxx # this is the registry password
#      tls:
#        cert_file: # path to the cert file used in the registry
#        key_file:  # path to the key file used in the registry
#        ca_file:   # path to the ca file used in the registry
# ....
```
Configuration in containerd can be used to connect to a private registry with a TLS connection and with registries that enable authentication as well. 

will gen `/etc/rancher/k3s/registries.yaml` when you use containerd  runtime.
