### PR TITLE
fix: only deploy templates on primary controller

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,22 +61,22 @@ below.
 Below are variables that are set against all of the play hosts for environment
 consistency. These are generally cluster-level configuration.
 
-| Variable                         | Description                                                                     | Default Value                  |
-|----------------------------------|---------------------------------------------------------------------------------|--------------------------------|
-| `k3s_state`                      | State of k3s: installed, started, stopped, downloaded, uninstalled, validated.  | installed                      |
-| `k3s_release_version`            | Use a specific version of k3s, eg. `v0.2.0`. Specify `false` for stable.        | `false`                        |
-| `k3s_config_file`                | Location of the k3s configuration file.                                         | `/etc/rancher/k3s/config.yaml` |
-| `k3s_build_cluster`              | When multiple play hosts are available, attempt to cluster. Read notes below.   | `true`                         |
-| `k3s_registration_address`       | Fixed registration address for nodes. IP or FQDN.                               | NULL                           |
-| `k3s_github_url`                 | Set the GitHub URL to install k3s from.                                         | https://github.com/k3s-io/k3s  |
-| `k3s_install_dir`                | Installation directory for k3s.                                                 | `/usr/local/bin`               |
-| `k3s_install_hard_links`         | Install using hard links rather than symbolic links.                            | `false`                        |
-| `k3s_server_manifests_templates` | A list of Auto-Deploying Manifests Templates.                                   | []                             |
-| `k3s_use_experimental`           | Allow the use of experimental features in k3s.                                  | `false`                        |
-| `k3s_use_unsupported_config`     | Allow the use of unsupported configurations in k3s.                             | `false`                        |
-| `k3s_etcd_datastore`             | Enable etcd embedded datastore (read notes below).                              | `false`                        |
-| `k3s_debug`                      | Enable debug logging on the k3s service.                                        | `false`                        |
-| `k3s_registries`                 | Registries configuration file content.                                          | `{ mirrors: {}, configs:{} }`  |
+| Variable                         | Description                                                                        | Default Value                  |
+|----------------------------------|------------------------------------------------------------------------------------|--------------------------------|
+| `k3s_state`                      | State of k3s: installed, started, stopped, downloaded, uninstalled, validated.     | installed                      |
+| `k3s_release_version`            | Use a specific version of k3s, eg. `v0.2.0`. Specify `false` for stable.           | `false`                        |
+| `k3s_config_file`                | Location of the k3s configuration file.                                            | `/etc/rancher/k3s/config.yaml` |
+| `k3s_build_cluster`              | When multiple play hosts are available, attempt to cluster. Read notes below.      | `true`                         |
+| `k3s_registration_address`       | Fixed registration address for nodes. IP or FQDN.                                  | NULL                           |
+| `k3s_github_url`                 | Set the GitHub URL to install k3s from.                                            | https://github.com/k3s-io/k3s  |
+| `k3s_install_dir`                | Installation directory for k3s.                                                    | `/usr/local/bin`               |
+| `k3s_install_hard_links`         | Install using hard links rather than symbolic links.                               | `false`                        |
+| `k3s_server_manifests_templates` | A list of Auto-Deploying Manifests Templates (only deploys on primary controller). | []                             |
+| `k3s_use_experimental`           | Allow the use of experimental features in k3s.                                     | `false`                        |
+| `k3s_use_unsupported_config`     | Allow the use of unsupported configurations in k3s.                                | `false`                        |
+| `k3s_etcd_datastore`             | Enable etcd embedded datastore (read notes below).                                 | `false`                        |
+| `k3s_debug`                      | Enable debug logging on the k3s service.                                           | `false`                        |
+| `k3s_registries`                 | Registries configuration file content.                                             | `{ mirrors: {}, configs:{} }`  |
 
 ### K3S Service Configuration
 

--- a/tasks/build/preconfigure-k3s-auto-deploying-manifests.yml
+++ b/tasks/build/preconfigure-k3s-auto-deploying-manifests.yml
@@ -10,7 +10,6 @@
 
 # https://rancher.com/docs/k3s/latest/en/advanced/#auto-deploying-manifests
 - name: Ensure auto-deploying manifests are copied to the primary controller
-  run_once: true
   ansible.builtin.template:
     src: "{{ item }}"
     dest: "{{ k3s_server_manifests_dir }}/{{ item | basename | replace('.j2','') }}"

--- a/tasks/build/preconfigure-k3s-auto-deploying-manifests.yml
+++ b/tasks/build/preconfigure-k3s-auto-deploying-manifests.yml
@@ -9,7 +9,8 @@
   become: "{{ k3s_become_for_directory_creation | ternary(true, false, k3s_become_for_all) }}"
 
 # https://rancher.com/docs/k3s/latest/en/advanced/#auto-deploying-manifests
-- name: Ensure auto-deploying manifests are copied to controllers
+- name: Ensure auto-deploying manifests are copied to the primary controller
+  run_once: true
   ansible.builtin.template:
     src: "{{ item }}"
     dest: "{{ k3s_server_manifests_dir }}/{{ item | basename | replace('.j2','') }}"

--- a/tasks/state-installed.yml
+++ b/tasks/state-installed.yml
@@ -36,7 +36,7 @@
 
 - import_tasks: build/preconfigure-k3s-auto-deploying-manifests.yml
   when:
-    - k3s_control_node
+    - k3s_primary_control_node
     - k3s_server_manifests_templates | length > 0
 
 - import_tasks: build/install-k3s.yml


### PR DESCRIPTION
## TITLE

### Summary

<!-- Describe the change below, including rationale and design decisions -->

<!-- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

k3s only needs manifests deployed to one controller in every case I've seen.

This PR make it so manifests are only deployed (when using `k3s_server_manifests_dir`) to the primary controller, README updated to note this.

### Issue type

<!-- Pick one below and delete the rest -->
- Bugfix

### Test instructions

<!-- Please provide instructions for testing this PR -->

Use `k3s_server_manifests_dir`, the manifest should only be on the primary controller

Related to https://github.com/PyratLabs/ansible-role-k3s/issues/117