### PR TITLE
Allow control plane static pods

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,23 +61,23 @@ below.
 Below are variables that are set against all of the play hosts for environment
 consistency. These are generally cluster-level configuration.
 
-| Variable                          | Description                                                                     | Default Value                  |
-|-----------------------------------|---------------------------------------------------------------------------------|--------------------------------|
-| `k3s_state`                       | State of k3s: installed, started, stopped, downloaded, uninstalled, validated.  | installed                      |
-| `k3s_release_version`             | Use a specific version of k3s, eg. `v0.2.0`. Specify `false` for stable.        | `false`                        |
-| `k3s_config_file`                 | Location of the k3s configuration file.                                         | `/etc/rancher/k3s/config.yaml` |
-| `k3s_build_cluster`               | When multiple play hosts are available, attempt to cluster. Read notes below.   | `true`                         |
-| `k3s_registration_address`        | Fixed registration address for nodes. IP or FQDN.                               | NULL                           |
-| `k3s_github_url`                  | Set the GitHub URL to install k3s from.                                         | https://github.com/k3s-io/k3s  |
-| `k3s_install_dir`                 | Installation directory for k3s.                                                 | `/usr/local/bin`               |
-| `k3s_install_hard_links`          | Install using hard links rather than symbolic links.                            | `false`                        |
-| `k3s_server_manifests_templates`  | A list of Auto-Deploying Manifests Templates.                                   | []                             |
-| `k3s_server_staticpods_templates` | A list of templates for installing static pods on the control plane.            | []                             |
-| `k3s_use_experimental`            | Allow the use of experimental features in k3s.                                  | `false`                        |
-| `k3s_use_unsupported_config`      | Allow the use of unsupported configurations in k3s.                             | `false`                        |
-| `k3s_etcd_datastore`              | Enable etcd embedded datastore (read notes below).                              | `false`                        |
-| `k3s_debug`                       | Enable debug logging on the k3s service.                                        | `false`                        |
-| `k3s_registries`                  | Registries configuration file content.                                          | `{ mirrors: {}, configs:{} }`  |
+| Variable                              | Description                                                                     | Default Value                  |
+|---------------------------------------|---------------------------------------------------------------------------------|--------------------------------|
+| `k3s_state`                           | State of k3s: installed, started, stopped, downloaded, uninstalled, validated.  | installed                      |
+| `k3s_release_version`                 | Use a specific version of k3s, eg. `v0.2.0`. Specify `false` for stable.        | `false`                        |
+| `k3s_config_file`                     | Location of the k3s configuration file.                                         | `/etc/rancher/k3s/config.yaml` |
+| `k3s_build_cluster`                   | When multiple play hosts are available, attempt to cluster. Read notes below.   | `true`                         |
+| `k3s_registration_address`            | Fixed registration address for nodes. IP or FQDN.                               | NULL                           |
+| `k3s_github_url`                      | Set the GitHub URL to install k3s from.                                         | https://github.com/k3s-io/k3s  |
+| `k3s_install_dir`                     | Installation directory for k3s.                                                 | `/usr/local/bin`               |
+| `k3s_install_hard_links`              | Install using hard links rather than symbolic links.                            | `false`                        |
+| `k3s_server_pod_manifests_templates`  | A list of Auto-Deploying Manifests Templates.                                   | []                             |
+| `k3s_server_staticpods_templates`     | A list of templates for installing static pod manifests on the control plane.   | []                             |
+| `k3s_use_experimental`                | Allow the use of experimental features in k3s.                                  | `false`                        |
+| `k3s_use_unsupported_config`          | Allow the use of unsupported configurations in k3s.                             | `false`                        |
+| `k3s_etcd_datastore`                  | Enable etcd embedded datastore (read notes below).                              | `false`                        |
+| `k3s_debug`                           | Enable debug logging on the k3s service.                                        | `false`                        |
+| `k3s_registries`                      | Registries configuration file content.                                          | `{ mirrors: {}, configs:{} }`  |
 
 ### K3S Service Configuration
 

--- a/README.md
+++ b/README.md
@@ -61,22 +61,23 @@ below.
 Below are variables that are set against all of the play hosts for environment
 consistency. These are generally cluster-level configuration.
 
-| Variable                         | Description                                                                     | Default Value                  |
-|----------------------------------|---------------------------------------------------------------------------------|--------------------------------|
-| `k3s_state`                      | State of k3s: installed, started, stopped, downloaded, uninstalled, validated.  | installed                      |
-| `k3s_release_version`            | Use a specific version of k3s, eg. `v0.2.0`. Specify `false` for stable.        | `false`                        |
-| `k3s_config_file`                | Location of the k3s configuration file.                                         | `/etc/rancher/k3s/config.yaml` |
-| `k3s_build_cluster`              | When multiple play hosts are available, attempt to cluster. Read notes below.   | `true`                         |
-| `k3s_registration_address`       | Fixed registration address for nodes. IP or FQDN.                               | NULL                           |
-| `k3s_github_url`                 | Set the GitHub URL to install k3s from.                                         | https://github.com/k3s-io/k3s  |
-| `k3s_install_dir`                | Installation directory for k3s.                                                 | `/usr/local/bin`               |
-| `k3s_install_hard_links`         | Install using hard links rather than symbolic links.                            | `false`                        |
-| `k3s_server_manifests_templates` | A list of Auto-Deploying Manifests Templates.                                   | []                             |
-| `k3s_use_experimental`           | Allow the use of experimental features in k3s.                                  | `false`                        |
-| `k3s_use_unsupported_config`     | Allow the use of unsupported configurations in k3s.                             | `false`                        |
-| `k3s_etcd_datastore`             | Enable etcd embedded datastore (read notes below).                              | `false`                        |
-| `k3s_debug`                      | Enable debug logging on the k3s service.                                        | `false`                        |
-| `k3s_registries`                 | Registries configuration file content.                                          | `{ mirrors: {}, configs:{} }`  |
+| Variable                          | Description                                                                     | Default Value                  |
+|-----------------------------------|---------------------------------------------------------------------------------|--------------------------------|
+| `k3s_state`                       | State of k3s: installed, started, stopped, downloaded, uninstalled, validated.  | installed                      |
+| `k3s_release_version`             | Use a specific version of k3s, eg. `v0.2.0`. Specify `false` for stable.        | `false`                        |
+| `k3s_config_file`                 | Location of the k3s configuration file.                                         | `/etc/rancher/k3s/config.yaml` |
+| `k3s_build_cluster`               | When multiple play hosts are available, attempt to cluster. Read notes below.   | `true`                         |
+| `k3s_registration_address`        | Fixed registration address for nodes. IP or FQDN.                               | NULL                           |
+| `k3s_github_url`                  | Set the GitHub URL to install k3s from.                                         | https://github.com/k3s-io/k3s  |
+| `k3s_install_dir`                 | Installation directory for k3s.                                                 | `/usr/local/bin`               |
+| `k3s_install_hard_links`          | Install using hard links rather than symbolic links.                            | `false`                        |
+| `k3s_server_manifests_templates`  | A list of Auto-Deploying Manifests Templates.                                   | []                             |
+| `k3s_server_staticpods_templates` | A list of templates for installing static pods on the control plane.            | []                             |
+| `k3s_use_experimental`            | Allow the use of experimental features in k3s.                                  | `false`                        |
+| `k3s_use_unsupported_config`      | Allow the use of unsupported configurations in k3s.                             | `false`                        |
+| `k3s_etcd_datastore`              | Enable etcd embedded datastore (read notes below).                              | `false`                        |
+| `k3s_debug`                       | Enable debug logging on the k3s service.                                        | `false`                        |
+| `k3s_registries`                  | Registries configuration file content.                                          | `{ mirrors: {}, configs:{} }`  |
 
 ### K3S Service Configuration
 

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ consistency. These are generally cluster-level configuration.
 | `k3s_install_dir`                     | Installation directory for k3s.                                                    | `/usr/local/bin`               |
 | `k3s_install_hard_links`              | Install using hard links rather than symbolic links.                               | `false`                        |
 | `k3s_server_manifests_templates`      | A list of Auto-Deploying Manifests Templates (only deploys on primary controller). | []                             |
-| `k3s_server_staticpods_templates`     | A list of templates for installing static pod manifests on the control plane.      | []                             |
+| `k3s_server_pod_manifests_templates`  | A list of templates for installing static pod manifests on the control plane.      | []                             |
 | `k3s_use_experimental`                | Allow the use of experimental features in k3s.                                     | `false`                        |
 | `k3s_use_unsupported_config`          | Allow the use of unsupported configurations in k3s.                                | `false`                        |
 | `k3s_etcd_datastore`                  | Enable etcd embedded datastore (read notes below).                                 | `false`                        |

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -38,8 +38,8 @@ k3s_install_hard_links: false
 # A list of templates used for preconfigure the cluster.
 k3s_server_manifests_templates: []
 
-# A list of templates used for installing static pods on the control plane.
-k3s_server_staticpods_templates: []
+# A list of templates used for installing static pod manifests on the control plane.
+k3s_server_pod_manifests_templates: []
 
 # Use experimental features in k3s?
 k3s_use_experimental: false

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -38,6 +38,9 @@ k3s_install_hard_links: false
 # A list of templates used for preconfigure the cluster.
 k3s_server_manifests_templates: []
 
+# A list of templates used for installing static pods on the control plane.
+k3s_server_staticpods_templates: []
+
 # Use experimental features in k3s?
 k3s_use_experimental: false
 

--- a/tasks/build/preconfigure-k3s-static-pod-manifests.yml
+++ b/tasks/build/preconfigure-k3s-static-pod-manifests.yml
@@ -1,18 +1,18 @@
 ---
 
-- name: Ensure that the staticpods directory exists
+- name: Ensure that the pod-manifests directory exists
   ansible.builtin.file:
     state: directory
-    path: "{{ k3s_server_staticpods_dir }}"
+    path: "{{ k3s_server_pod_manifests_dir }}"
     mode: 0755
-  when: k3s_server_staticpods_templates | length > 0
+  when: k3s_server_pod_manifests_templates | length > 0
   become: "{{ k3s_become_for_directory_creation | ternary(true, false, k3s_become_for_all) }}"
 
 # https://github.com/k3s-io/k3s/pull/1691
 - name: Ensure static pod manifests are copied to controllers
   ansible.builtin.template:
     src: "{{ item }}"
-    dest: "{{ k3s_server_staticpods_dir }}/{{ item | basename | replace('.j2','') }}"
+    dest: "{{ k3s_server_pod_manifests_dir }}/{{ item | basename | replace('.j2','') }}"
     mode: 0644
-  loop: "{{ k3s_server_staticpods_templates }}"
+  loop: "{{ k3s_server_pod_manifests_templates }}"
   become: "{{ k3s_become_for_directory_creation | ternary(true, false, k3s_become_for_all) }}"

--- a/tasks/build/preconfigure-k3s-static-pods.yml
+++ b/tasks/build/preconfigure-k3s-static-pods.yml
@@ -1,0 +1,18 @@
+---
+
+- name: Ensure that the staticpods directory exists
+  ansible.builtin.file:
+    state: directory
+    path: "{{ k3s_server_staticpods_dir }}"
+    mode: 0755
+  when: k3s_server_staticpods_templates | length > 0
+  become: "{{ k3s_become_for_directory_creation | ternary(true, false, k3s_become_for_all) }}"
+
+# https://github.com/k3s-io/k3s/pull/1691
+- name: Ensure static pod manifests are copied to controllers
+  ansible.builtin.template:
+    src: "{{ item }}"
+    dest: "{{ k3s_server_staticpods_dir }}/{{ item | basename | replace('.j2','') }}"
+    mode: 0644
+  loop: "{{ k3s_server_staticpods_templates }}"
+  become: "{{ k3s_become_for_directory_creation | ternary(true, false, k3s_become_for_all) }}"

--- a/tasks/state-installed.yml
+++ b/tasks/state-installed.yml
@@ -39,6 +39,11 @@
     - k3s_control_node
     - k3s_server_manifests_templates | length > 0
 
+- import_tasks: build/preconfigure-k3s-static-pods.yml
+  when:
+    - k3s_control_node
+    - k3s_server_staticpods_templates | length > 0
+
 - import_tasks: build/install-k3s.yml
 
 - name: Ensure containerd installation tasks are run

--- a/tasks/state-installed.yml
+++ b/tasks/state-installed.yml
@@ -39,10 +39,10 @@
     - k3s_control_node
     - k3s_server_manifests_templates | length > 0
 
-- import_tasks: build/preconfigure-k3s-static-pods.yml
+- import_tasks: build/preconfigure-k3s-static-pod-manifests.yml
   when:
     - k3s_control_node
-    - k3s_server_staticpods_templates | length > 0
+    - k3s_server_pod_manifests_templates | length > 0
 
 - import_tasks: build/install-k3s.yml
 

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -84,6 +84,10 @@ k3s_token_location: "{{ k3s_config_dir }}/cluster-token"
 # https://rancher.com/docs/k3s/latest/en/advanced/#auto-deploying-manifests
 k3s_server_manifests_dir: "{{ k3s_data_dir }}/server/manifests"
 
+# Path for static pods that are deployed on the control plane
+# https://github.com/k3s-io/k3s/pull/1691
+k3s_server_staticpods_dir: "{{ k3s_data_dir }}/agent/staticpods"
+
 # Packages that we need to check are installed
 k3s_check_packages: []
 # - name: dummy

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -84,9 +84,9 @@ k3s_token_location: "{{ k3s_config_dir }}/cluster-token"
 # https://rancher.com/docs/k3s/latest/en/advanced/#auto-deploying-manifests
 k3s_server_manifests_dir: "{{ k3s_data_dir }}/server/manifests"
 
-# Path for static pods that are deployed on the control plane
+# Path for static pod manifests that are deployed on the control plane
 # https://github.com/k3s-io/k3s/pull/1691
-k3s_server_staticpods_dir: "{{ k3s_data_dir }}/agent/staticpods"
+k3s_server_pod_manifests_dir: "{{ k3s_data_dir }}/agent/pod-manifests"
 
 # Packages that we need to check are installed
 k3s_check_packages: []


### PR DESCRIPTION
## Allow control plane static pods

### Summary

This adds support for specifying static pod manifests through `k3s_server_pod_manifests_templates`, similar to how automatic manifests are being pre-configured with `k3s_server_manifests_templates`.

Fixes #118 

### Issue type

- Feature

### Test instructions

- Add a manifest to `k3s_server_pod_manifests_templates`, it should be deployed on all control plane nodes.
- K3s will start the manifest regardless of node state.
