### PR TITLE
feat: add support for specifying URLs in templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,23 +61,25 @@ below.
 Below are variables that are set against all of the play hosts for environment
 consistency. These are generally cluster-level configuration.
 
-| Variable                              | Description                                                                        | Default Value                  |
-|---------------------------------------|------------------------------------------------------------------------------------|--------------------------------|
-| `k3s_state`                           | State of k3s: installed, started, stopped, downloaded, uninstalled, validated.     | installed                      |
-| `k3s_release_version`                 | Use a specific version of k3s, eg. `v0.2.0`. Specify `false` for stable.           | `false`                        |
-| `k3s_config_file`                     | Location of the k3s configuration file.                                            | `/etc/rancher/k3s/config.yaml` |
-| `k3s_build_cluster`                   | When multiple play hosts are available, attempt to cluster. Read notes below.      | `true`                         |
-| `k3s_registration_address`            | Fixed registration address for nodes. IP or FQDN.                                  | NULL                           |
-| `k3s_github_url`                      | Set the GitHub URL to install k3s from.                                            | https://github.com/k3s-io/k3s  |
-| `k3s_install_dir`                     | Installation directory for k3s.                                                    | `/usr/local/bin`               |
-| `k3s_install_hard_links`              | Install using hard links rather than symbolic links.                               | `false`                        |
-| `k3s_server_manifests_templates`      | A list of Auto-Deploying Manifests Templates (only deploys on primary controller). | []                             |
-| `k3s_server_pod_manifests_templates`  | A list of templates for installing static pod manifests on the control plane.      | []                             |
-| `k3s_use_experimental`                | Allow the use of experimental features in k3s.                                     | `false`                        |
-| `k3s_use_unsupported_config`          | Allow the use of unsupported configurations in k3s.                                | `false`                        |
-| `k3s_etcd_datastore`                  | Enable etcd embedded datastore (read notes below).                                 | `false`                        |
-| `k3s_debug`                           | Enable debug logging on the k3s service.                                           | `false`                        |
-| `k3s_registries`                      | Registries configuration file content.                                             | `{ mirrors: {}, configs:{} }`  |
+| Variable                             | Description                                                                        | Default Value                  |
+|--------------------------------------|------------------------------------------------------------------------------------|--------------------------------|
+| `k3s_state`                          | State of k3s: installed, started, stopped, downloaded, uninstalled, validated.     | installed                      |
+| `k3s_release_version`                | Use a specific version of k3s, eg. `v0.2.0`. Specify `false` for stable.           | `false`                        |
+| `k3s_config_file`                    | Location of the k3s configuration file.                                            | `/etc/rancher/k3s/config.yaml` |
+| `k3s_build_cluster`                  | When multiple play hosts are available, attempt to cluster. Read notes below.      | `true`                         |
+| `k3s_registration_address`           | Fixed registration address for nodes. IP or FQDN.                                  | NULL                           |
+| `k3s_github_url`                     | Set the GitHub URL to install k3s from.                                            | https://github.com/k3s-io/k3s  |
+| `k3s_install_dir`                    | Installation directory for k3s.                                                    | `/usr/local/bin`               |
+| `k3s_install_hard_links`             | Install using hard links rather than symbolic links.                               | `false`                        |
+| `k3s_server_manifests_urls`          | A list of URLs to deploy on the primary control plane.                             | []                             |
+| `k3s_server_manifests_templates`     | A flat list of templates to deploy on the primary control plane.                   | []                             |
+| `k3s_server_pod_manifests_urls`      | A list of URLs for installing static pod manifests on the control plane.           | []                             |
+| `k3s_server_pod_manifests_templates` | A flat list of templates for installing static pod manifests on the control plane. | []                             |
+| `k3s_use_experimental`               | Allow the use of experimental features in k3s.                                     | `false`                        |
+| `k3s_use_unsupported_config`         | Allow the use of unsupported configurations in k3s.                                | `false`                        |
+| `k3s_etcd_datastore`                 | Enable etcd embedded datastore (read notes below).                                 | `false`                        |
+| `k3s_debug`                          | Enable debug logging on the k3s service.                                           | `false`                        |
+| `k3s_registries`                     | Registries configuration file content.                                             | `{ mirrors: {}, configs:{} }`  |
 
 ### K3S Service Configuration
 

--- a/README.md
+++ b/README.md
@@ -61,25 +61,25 @@ below.
 Below are variables that are set against all of the play hosts for environment
 consistency. These are generally cluster-level configuration.
 
-| Variable                             | Description                                                                        | Default Value                  |
-|--------------------------------------|------------------------------------------------------------------------------------|--------------------------------|
-| `k3s_state`                          | State of k3s: installed, started, stopped, downloaded, uninstalled, validated.     | installed                      |
-| `k3s_release_version`                | Use a specific version of k3s, eg. `v0.2.0`. Specify `false` for stable.           | `false`                        |
-| `k3s_config_file`                    | Location of the k3s configuration file.                                            | `/etc/rancher/k3s/config.yaml` |
-| `k3s_build_cluster`                  | When multiple play hosts are available, attempt to cluster. Read notes below.      | `true`                         |
-| `k3s_registration_address`           | Fixed registration address for nodes. IP or FQDN.                                  | NULL                           |
-| `k3s_github_url`                     | Set the GitHub URL to install k3s from.                                            | https://github.com/k3s-io/k3s  |
-| `k3s_install_dir`                    | Installation directory for k3s.                                                    | `/usr/local/bin`               |
-| `k3s_install_hard_links`             | Install using hard links rather than symbolic links.                               | `false`                        |
-| `k3s_server_manifests_urls`          | A list of URLs to deploy on the primary control plane.                             | []                             |
-| `k3s_server_manifests_templates`     | A flat list of templates to deploy on the primary control plane.                   | []                             |
-| `k3s_server_pod_manifests_urls`      | A list of URLs for installing static pod manifests on the control plane.           | []                             |
-| `k3s_server_pod_manifests_templates` | A flat list of templates for installing static pod manifests on the control plane. | []                             |
-| `k3s_use_experimental`               | Allow the use of experimental features in k3s.                                     | `false`                        |
-| `k3s_use_unsupported_config`         | Allow the use of unsupported configurations in k3s.                                | `false`                        |
-| `k3s_etcd_datastore`                 | Enable etcd embedded datastore (read notes below).                                 | `false`                        |
-| `k3s_debug`                          | Enable debug logging on the k3s service.                                           | `false`                        |
-| `k3s_registries`                     | Registries configuration file content.                                             | `{ mirrors: {}, configs:{} }`  |
+| Variable                             | Description                                                                                    | Default Value                  |
+|--------------------------------------|------------------------------------------------------------------------------------------------|--------------------------------|
+| `k3s_state`                          | State of k3s: installed, started, stopped, downloaded, uninstalled, validated.                 | installed                      |
+| `k3s_release_version`                | Use a specific version of k3s, eg. `v0.2.0`. Specify `false` for stable.                       | `false`                        |
+| `k3s_config_file`                    | Location of the k3s configuration file.                                                        | `/etc/rancher/k3s/config.yaml` |
+| `k3s_build_cluster`                  | When multiple play hosts are available, attempt to cluster. Read notes below.                  | `true`                         |
+| `k3s_registration_address`           | Fixed registration address for nodes. IP or FQDN.                                              | NULL                           |
+| `k3s_github_url`                     | Set the GitHub URL to install k3s from.                                                        | https://github.com/k3s-io/k3s  |
+| `k3s_install_dir`                    | Installation directory for k3s.                                                                | `/usr/local/bin`               |
+| `k3s_install_hard_links`             | Install using hard links rather than symbolic links.                                           | `false`                        |
+| `k3s_server_manifests_urls`          | A list of URLs (w/ url and filename) to deploy on the primary control plane.                   | []                             |
+| `k3s_server_manifests_templates`     | A flat list of templates to deploy on the primary control plane.                               | []                             |
+| `k3s_server_pod_manifests_urls`      | A list of URLs (w/ url and filename) for installing static pod manifests on the control plane. | []                             |
+| `k3s_server_pod_manifests_templates` | A flat list of templates for installing static pod manifests on the control plane.             | []                             |
+| `k3s_use_experimental`               | Allow the use of experimental features in k3s.                                                 | `false`                        |
+| `k3s_use_unsupported_config`         | Allow the use of unsupported configurations in k3s.                                            | `false`                        |
+| `k3s_etcd_datastore`                 | Enable etcd embedded datastore (read notes below).                                             | `false`                        |
+| `k3s_debug`                          | Enable debug logging on the k3s service.                                                       | `false`                        |
+| `k3s_registries`                     | Registries configuration file content.                                                         | `{ mirrors: {}, configs:{} }`  |
 
 ### K3S Service Configuration
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -38,8 +38,14 @@ k3s_install_hard_links: false
 # A list of templates used for preconfigure the cluster.
 k3s_server_manifests_templates: []
 
+# A list of URLs used for preconfigure the cluster.
+k3s_server_manifests_urls: []
+
 # A list of templates used for installing static pod manifests on the control plane.
 k3s_server_pod_manifests_templates: []
+
+# A list of URLs used for installing static pod manifests on the control plane.
+k3s_server_pod_manifests_urls: []
 
 # Use experimental features in k3s?
 k3s_use_experimental: false

--- a/tasks/build/preconfigure-k3s-auto-deploying-manifests-urls.yml
+++ b/tasks/build/preconfigure-k3s-auto-deploying-manifests-urls.yml
@@ -1,0 +1,18 @@
+---
+
+- name: Ensure that the manifests directory exists
+  ansible.builtin.file:
+    state: directory
+    path: "{{ k3s_server_manifests_dir }}"
+    mode: 0755
+  when: k3s_server_manifests_urls | length > 0
+  become: "{{ k3s_become_for_directory_creation | ternary(true, false, k3s_become_for_all) }}"
+
+# https://rancher.com/docs/k3s/latest/en/advanced/#auto-deploying-manifests
+- name: Ensure auto-deploying manifests are downloaded to the primary controller
+  ansible.builtin.get_url:
+    url: "{{ item.url }}"
+    dest: "{{ k3s_server_manifests_dir }}/{{ item.filename }}"
+    mode: 0644
+  loop: "{{ k3s_server_manifests_urls }}"
+  become: "{{ k3s_become_for_directory_creation | ternary(true, false, k3s_become_for_all) }}"

--- a/tasks/build/preconfigure-k3s-static-pod-manifests-urls.yml
+++ b/tasks/build/preconfigure-k3s-static-pod-manifests-urls.yml
@@ -1,0 +1,18 @@
+---
+
+- name: Ensure that the manifests directory exists
+  ansible.builtin.file:
+    state: directory
+    path: "{{ k3s_server_manifests_dir }}"
+    mode: 0755
+  when: k3s_server_pod_manifests_urls | length > 0
+  become: "{{ k3s_become_for_directory_creation | ternary(true, false, k3s_become_for_all) }}"
+
+# https://rancher.com/docs/k3s/latest/en/advanced/#auto-deploying-manifests
+- name: Ensure auto-deploying manifests are downloaded to the primary controller
+  ansible.builtin.get_url:
+    url: "{{ item.url }}"
+    dest: "{{ k3s_server_manifests_dir }}/{{ item.filename }}"
+    mode: 0644
+  loop: "{{ k3s_server_pod_manifests_urls }}"
+  become: "{{ k3s_become_for_directory_creation | ternary(true, false, k3s_become_for_all) }}"

--- a/tasks/build/preconfigure-k3s-static-pod-manifests-urls.yml
+++ b/tasks/build/preconfigure-k3s-static-pod-manifests-urls.yml
@@ -3,7 +3,7 @@
 - name: Ensure that the manifests directory exists
   ansible.builtin.file:
     state: directory
-    path: "{{ k3s_server_manifests_dir }}"
+    path: "{{ k3s_server_pod_manifests_dir }}"
     mode: 0755
   when: k3s_server_pod_manifests_urls | length > 0
   become: "{{ k3s_become_for_directory_creation | ternary(true, false, k3s_become_for_all) }}"
@@ -12,7 +12,7 @@
 - name: Ensure auto-deploying manifests are downloaded to the primary controller
   ansible.builtin.get_url:
     url: "{{ item.url }}"
-    dest: "{{ k3s_server_manifests_dir }}/{{ item.filename }}"
+    dest: "{{ k3s_server_pod_manifests_dir }}/{{ item.filename }}"
     mode: 0644
   loop: "{{ k3s_server_pod_manifests_urls }}"
   become: "{{ k3s_become_for_directory_creation | ternary(true, false, k3s_become_for_all) }}"

--- a/tasks/build/preconfigure-k3s-static-pod-manifests-urls.yml
+++ b/tasks/build/preconfigure-k3s-static-pod-manifests-urls.yml
@@ -1,6 +1,6 @@
 ---
 
-- name: Ensure that the manifests directory exists
+- name: Ensure that the pod-manifests directory exists
   ansible.builtin.file:
     state: directory
     path: "{{ k3s_server_pod_manifests_dir }}"

--- a/tasks/state-installed.yml
+++ b/tasks/state-installed.yml
@@ -39,10 +39,20 @@
     - k3s_primary_control_node
     - k3s_server_manifests_templates | length > 0
 
+- import_tasks: build/preconfigure-k3s-auto-deploying-manifests-urls.yml
+  when:
+    - k3s_primary_control_node
+    - k3s_server_manifests_urls | length > 0
+
 - import_tasks: build/preconfigure-k3s-static-pod-manifests.yml
   when:
     - k3s_control_node
     - k3s_server_pod_manifests_templates | length > 0
+
+- import_tasks: build/preconfigure-k3s-static-pod-manifests-urls.yml
+  when:
+    - k3s_control_node
+    - k3s_server_pod_manifests_urls | length > 0
 
 - import_tasks: build/install-k3s.yml
 


### PR DESCRIPTION
### Summary

Adds support for specifying URLs to auto deploy

### Issue type

- Feature

### Test instructions

```
k3s_server_manifests_urls:
- url: https://docs.projectcalico.org/archive/v3.19/manifests/tigera-operator.yaml
  filename: tigera-operator.yaml

k3s_server_pod_manifests_urls:
- url: https://raw.githubusercontent.com/kube-vip/kube-vip/main/example/deploy/0.1.4.yaml
  filename: kube-vip.yaml
```

### Acceptance Criteria

- [x] Documentation updated.

