### PR TITLE
Case insensitive control node lookup

### DIFF
--- a/tasks/build/preconfigure-k3s.yml
+++ b/tasks/build/preconfigure-k3s.yml
@@ -86,7 +86,7 @@
   block:
     - name: Lookup control node from file
       ansible.builtin.command:
-        cmd: "grep '{{ 'P_True' if (k3s_controller_list | length > 1) else 'C_True' }}' /tmp/inventory.txt"
+        cmd: "grep -i '{{ 'P_True' if (k3s_controller_list | length > 1) else 'C_True' }}' /tmp/inventory.txt"
       changed_when: false
       check_mode: false
       register: k3s_control_delegate_raw


### PR DESCRIPTION
## Fix: case insensitive control node lookup

### Summary

Apologies for the lack of info, using this role is my first foray into the world of Ansible.

This PR fixes an issue I was running into where my `/tmp/inventory.txt` file didn't contain `C_True`, but it did contain `C_true`. Didn't seem to me like the casing matters so I threw a `-i` on the `grep` command and everything started working.

```
 $ ssh <a node> -- sudo cat /tmp/inventory.txt  
# BEGIN ANSIBLE MANAGED BLOCK
<node1> @@@ <node1>  @@@ C_False @@@ P_False @@@ END:<node1> 
<node2> @@@ <node2> @@@ C_False @@@ P_False @@@ END:<node2>
<node3> @@@ <node3> @@@ C_False @@@ P_False @@@ END:<node3>
<node4 (primary)> @@@ <node4 (primary)> @@@ C_true @@@ P_False @@@ END:<node4 (primary)>
# END ANSIBLE MANAGED BLOCK
```

I am setting `k3s_control_node=true` on my primary node in the inventory.

### Issue type
- Bugfix
