### PR TITLE
fix: restore clustering and avoid failure with jinja2_native=true

### DIFF
--- a/tasks/build/preconfigure-k3s.yml
+++ b/tasks/build/preconfigure-k3s.yml
@@ -9,12 +9,12 @@
 
 - name: Ensure k3s control node fact is set
   ansible.builtin.set_fact:
-    k3s_control_node: "{{ 'false' if k3s_build_cluster else 'true' }}"
+    k3s_control_node: "{{ false if k3s_build_cluster else true }}"
   when: k3s_control_node is not defined
 
 - name: Ensure k3s primary control node fact is set
   ansible.builtin.set_fact:
-    k3s_primary_control_node: "{{ 'false' if k3s_build_cluster else 'true' }}"
+    k3s_primary_control_node: "{{ false if k3s_build_cluster else true }}"
   when: k3s_primary_control_node is not defined
 
 - name: Ensure k3s control plane port is captured

--- a/tasks/build/preconfigure-k3s.yml
+++ b/tasks/build/preconfigure-k3s.yml
@@ -69,11 +69,11 @@
       {% filter replace('\n', ' ') %}
       {{ host }}
       @@@
-      {{ hostvars[host].ansible_host | default(hostvars[host].ansible_fqdn) }}
+      {{ hostvars[host].ansible_host | default(hostvars[host].ansible_fqdn) | string }}
       @@@
-      C_{{ hostvars[host].k3s_control_node }}
+      C_{{ hostvars[host].k3s_control_node | string }}
       @@@
-      P_{{ hostvars[host].k3s_primary_control_node | default(False) }}
+      P_{{ hostvars[host].k3s_primary_control_node | default(False) | string }}
       {% endfilter %}
       @@@ END:{{ host }}
       {% endfor %}

--- a/templates/k3s.service.j2
+++ b/templates/k3s.service.j2
@@ -29,7 +29,7 @@ ExecStart={{ k3s_install_dir }}/k3s
 {% if k3s_control_node %}
     server
     {% if (k3s_etcd_datastore is defined and k3s_etcd_datastore) and (k3s_primary_control_node is not defined or not k3s_primary_control_node) and k3s_controller_list | length > 1 %}
-        --server https://{{ k3s_registration_address }}:{{ k3s_control_plane_port | default(6443) }}
+        --server https://{{ k3s_registration_address }}:{{ k3s_control_plane_port | default(6443) | string }}
         --token-file {{ k3s_token_location }}
     {% endif %}
     {% if k3s_server is defined %}
@@ -37,7 +37,7 @@ ExecStart={{ k3s_install_dir }}/k3s
     {% endif %}
 {% else %}
     agent
-    --server https://{{ k3s_registration_address }}:{{ k3s_control_plane_port | default(6443) }}
+    --server https://{{ k3s_registration_address }}:{{ k3s_control_plane_port | default(6443) | string }}
     --token-file {{ k3s_token_location }}
     {% if k3s_agent is defined %}
         --config {{ k3s_config_file }}


### PR DESCRIPTION
### Summary

<!-- Describe the change below, including rationale and design decisions -->

<!-- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
If you run the role on an ansible configured with that setting, it will fail with:
    
    fatal: [vm0]: FAILED! => {"msg": "Unexpected templating type error occurred on ({% for host in ansible_play_hosts_all %}\n{% filter string %}\n{% filter replace('\\n', ' ') %}\n{{ host }}\n@@@\n{{ hostvars[host].ansible_host | default(hostvars[host].ansible_fqdn) }}\n@@@\nC_{{ hostvars[host].k3s_control_node }}\n@@@\nP_{{ hostvars[host].k3s_primary_control_node | default(False) }}\n{% endfilter %}\n{% endfilter %}\n@@@ END:{{ host }}\n{% endfor %}): sequence item 4: expected str instance, bool found"}

### Issue type

<!-- Pick one below and delete the rest -->
- Bugfix


### Test instructions

<!-- Please provide instructions for testing this PR -->

Just run the playbook prefixing the command with `env ANSIBLE_JINJA2_NATIVE=true` and see that it works now.
