### PR TITLE
fix: do ignore etcd member count when uninstalling

### DIFF
--- a/tasks/validate/configuration/control-node-count.yml
+++ b/tasks/validate/configuration/control-node-count.yml
@@ -43,3 +43,4 @@
     - k3s_etcd_datastore
     - not k3s_use_unsupported_config
     - k3s_control_node
+    - k3s_state != 'uninstalled'


### PR DESCRIPTION


## TITLE

### Summary

<!-- Describe the change below, including rationale and design decisions -->

<!-- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Otherwise, when completely uninstalling the etcd-enabled cluster, it fails with:

```
TASK [xanmanning.k3s : Check the conditions when embedded etcd is defined] ***************************************
fatal: [vm0]: FAILED! => {
    "assertion": "(((k3s_controller_list | length) % 2) == 1)",
    "changed": false,
    "evaluated_to": false,
    "msg": "Etcd should have a minimum of 3 defined members and the number of members should be odd. Please see notes about HA in README.md"
}
fatal: [vm1]: FAILED! => {
    "assertion": "(((k3s_controller_list | length) % 2) == 1)",
    "changed": false,
    "evaluated_to": false,
    "msg": "Etcd should have a minimum of 3 defined members and the number of members should be odd. Please see notes about HA in README.md"
}
fatal: [vm2]: FAILED! => {
    "assertion": "(((k3s_controller_list | length) % 2) == 1)",
    "changed": false,
    "evaluated_to": false,
    "msg": "Etcd should have a minimum of 3 defined members and the number of members should be odd. Please see notes about HA in README.md"
}
```

### Issue type

<!-- Pick one below and delete the rest -->
- Bugfix

