### PR TITLE
Add advertised address

### DIFF
--- a/tasks/build/preconfigure-k3s.yml
+++ b/tasks/build/preconfigure-k3s.yml
@@ -102,6 +102,24 @@
       check_mode: false
       when: k3s_control_node_address is defined
 
+    - name: Ensure the node registration address is defined from server node ip
+      ansible.builtin.set_fact:
+        k3s_registration_address: "{{ hostvars[k3s_control_delegate].k3s_server['node-ip'] }}"
+      check_mode: false
+      when:
+        - k3s_registration_address is not defined
+        - k3s_control_node_address is not defined
+        - hostvars[k3s_control_delegate].k3s_server['node-ip'] is defined
+
+    - name: Ensure the node registration address is defined from agent node ip
+      ansible.builtin.set_fact:
+        k3s_registration_address: "{{ hostvars[k3s_control_delegate].k3s_agent['node-ip'] }}"
+      check_mode: false
+      when:
+        - k3s_registration_address is not defined
+        - k3s_control_node_address is not defined
+        - hostvars[k3s_control_delegate].k3s_agent['node-ip'] is defined
+
     - name: Ensure the node registration address is defined
       ansible.builtin.set_fact:
         k3s_registration_address: "{{ hostvars[k3s_control_delegate].ansible_host | default(hostvars[k3s_control_delegate].ansible_fqdn) }}"

--- a/tasks/build/preconfigure-k3s.yml
+++ b/tasks/build/preconfigure-k3s.yml
@@ -102,23 +102,14 @@
       check_mode: false
       when: k3s_control_node_address is defined
 
-    - name: Ensure the node registration address is defined from server node ip
+    - name: Ensure the node registration address is defined from node-ip
       ansible.builtin.set_fact:
-        k3s_registration_address: "{{ hostvars[k3s_control_delegate].k3s_server['node-ip'] }}"
+        k3s_registration_address: "{{ hostvars[k3s_control_delegate].k3s_runtime_config['node-ip'] }}"
       check_mode: false
       when:
         - k3s_registration_address is not defined
         - k3s_control_node_address is not defined
-        - hostvars[k3s_control_delegate].k3s_server['node-ip'] is defined
-
-    - name: Ensure the node registration address is defined from agent node ip
-      ansible.builtin.set_fact:
-        k3s_registration_address: "{{ hostvars[k3s_control_delegate].k3s_agent['node-ip'] }}"
-      check_mode: false
-      when:
-        - k3s_registration_address is not defined
-        - k3s_control_node_address is not defined
-        - hostvars[k3s_control_delegate].k3s_agent['node-ip'] is defined
+        - hostvars[k3s_control_delegate].k3s_runtime_config['node-ip'] is defined
 
     - name: Ensure the node registration address is defined
       ansible.builtin.set_fact:
@@ -130,13 +121,6 @@
 
   when: k3s_registration_address is not defined
         or k3s_control_delegate is not defined
-
-- name: Ensure k3s_runtime_config is set for control plane
-  ansible.builtin.set_fact:
-    k3s_runtime_config: "{{ (k3s_server | default({})) | combine((k3s_agent | default({}))) }}"
-  when:
-    - (k3s_server is defined or k3s_agent is defined)
-    - (k3s_control_node is defined and k3s_control_node)
 
 - name: Ensure k3s_runtime_config is set for agents
   ansible.builtin.set_fact:


### PR DESCRIPTION
## Add advertised address

### Summary

<!-- Describe the change below, including rationale and design decisions -->

Add the option to specify an advertised address for each node in the cluster. This is useful when one uses a VPN and would like to use the address of the node in the VPN.

<!-- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

### Issue type

<!-- Pick one below and delete the rest -->
- Feature

### Test instructions

Define an (different) advertised address for each node (one can use `ansible_host`). See if the cluster builds.

### Acceptance Criteria

<!-- Please list criteria required to ensure this change has been sufficiently reviewed.  -->

  - [x] GitHub Actions Build passes.
  - [ ] Documentation updated.
  - [x] Runs without errors.

### Additional Information

<!-- Include additional information to help people understand the change here -->

<!-- Paste verbatim command output below, e.g. before and after your change -->

 [Here](https://github.com/arch-anes/self-hosted-services/blob/k3s/roles/kubernetes/tasks/install_k8s.yml#L17)'s an example of a project using this feature.