### PR TITLE
feat: added k3s_flannel_iface and k3s_node_external_ip options

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,11 +101,13 @@ for more information.
 Below are variables that are set against individual or groups of play hosts.
 Typically you'd set these at group level for the control plane or worker nodes.
 
-| Variable           | Description                                                       | Default Value                                     |
-|--------------------|-------------------------------------------------------------------|---------------------------------------------------|
-| `k3s_control_node` | Specify if a host (or host group) are part of the control plane.  | `false` (role will automatically delegate a node) |
-| `k3s_server`       | Server (control plane) configuration, see notes below.            | `{}`                                              |
-| `k3s_agent`        | Agent (worker) configuration, see notes below.                    | `{}`                                              |
+| Variable              | Description                                                       | Default Value                                     |
+|-----------------------|-------------------------------------------------------------------|---------------------------------------------------|
+| `k3s_control_node`    | Specify if a host (or host group) are part of the control plane.  | `false` (role will automatically delegate a node) |
+| `k3s_server`          | Server (control plane) configuration, see notes below.            | `{}`                                              |
+| `k3s_agent`           | Agent (worker) configuration, see notes below.                    | `{}`                                              |
+| `k3s_flannel_iface`   | Host flannel interface for k3s to use                             | `{}`                                              |
+| `k3s_node_external_ip`| External IP address to advertise for node                         | `{}`                                              |
 
 #### Server (Control Plane) Configuration
 

--- a/templates/k3s.service.j2
+++ b/templates/k3s.service.j2
@@ -37,6 +37,12 @@ ExecStart={{ k3s_install_dir }}/k3s
     {% if k3s_control_node and not k3s_primary_control_node %}
         --token-file {{ k3s_token_location }}
     {% endif %}
+    {% if 'k3s_node_external_ip' in hostvars[inventory_hostname] %}
+    --node-external-ip {{ hostvars[inventory_hostname].k3s_node_external_ip }}
+    {% endif %}
+    {% if 'k3s_flannel_iface' in hostvars[inventory_hostname] %}
+    --flannel-iface {{ hostvars[inventory_hostname].k3s_flannel_iface }}
+    {% endif %}
 {% else %}
     agent
     --server https://{{ k3s_registration_address }}:{{ k3s_control_plane_port | default(6443) | string }}


### PR DESCRIPTION
## added k3s_flannel_iface and k3s_node_external_ip options

### Summary

This PR add 2 new options in node inventory : 
- k3s_node_external_ip
- k3s_flannel_iface

Those options allow to select on which interface k3s should bind on the cluster nodes. This is especially useful should your cluster nodes have multiple network interfaces. By default, k3s select the first one (except for lo). 

### Issue type

<!-- Pick one below and delete the rest -->
- Documentation
- Feature

### Test instructions

This PR was tested with 3 nodes running Ubuntu 20.04.
Host inventory was defined this way: 
```
[k3s]
192.168.56.220 k3s_control_node=true k3s_flannel_iface=enp0s8 k3s_node_external_ip=192.168.56.220
192.168.56.221
192.168.56.222
```

### Acceptance Criteria

<!-- Please list criteria required to ensure this change has been sufficiently reviewed.  -->

<!-- Example ticklist:
  - [ ] GitHub Actions Build passes.
  - [ ] Documentation updated.
-->

### Additional Information

<!-- Include additional information to help people understand the change here -->

<!-- Paste verbatim command output below, e.g. before and after your change -->


