### PR TITLE
feat: implement config.yaml.d

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,25 +59,27 @@ below.
 Below are variables that are set against all of the play hosts for environment
 consistency. These are generally cluster-level configuration.
 
-| Variable                             | Description                                                                                    | Default Value                  |
-|--------------------------------------|------------------------------------------------------------------------------------------------|--------------------------------|
-| `k3s_state`                          | State of k3s: installed, started, stopped, downloaded, uninstalled, validated.                 | installed                      |
-| `k3s_release_version`                | Use a specific version of k3s, eg. `v0.2.0`. Specify `false` for stable.                       | `false`                        |
-| `k3s_config_file`                    | Location of the k3s configuration file.                                                        | `/etc/rancher/k3s/config.yaml` |
-| `k3s_build_cluster`                  | When multiple play hosts are available, attempt to cluster. Read notes below.                  | `true`                         |
-| `k3s_registration_address`           | Fixed registration address for nodes. IP or FQDN.                                              | NULL                           |
-| `k3s_github_url`                     | Set the GitHub URL to install k3s from.                                                        | https://github.com/k3s-io/k3s  |
-| `k3s_install_dir`                    | Installation directory for k3s.                                                                | `/usr/local/bin`               |
-| `k3s_install_hard_links`             | Install using hard links rather than symbolic links.                                           | `false`                        |
-| `k3s_server_manifests_urls`          | A list of URLs to deploy on the primary control plane. Read notes below.                       | []                             |
-| `k3s_server_manifests_templates`     | A flat list of templates to deploy on the primary control plane.                               | []                             |
-| `k3s_server_pod_manifests_urls`      | A list of URLs for installing static pod manifests on the control plane. Read notes below.     | []                             |
-| `k3s_server_pod_manifests_templates` | A flat list of templates for installing static pod manifests on the control plane.             | []                             |
-| `k3s_use_experimental`               | Allow the use of experimental features in k3s.                                                 | `false`                        |
-| `k3s_use_unsupported_config`         | Allow the use of unsupported configurations in k3s.                                            | `false`                        |
-| `k3s_etcd_datastore`                 | Enable etcd embedded datastore (read notes below).                                             | `false`                        |
-| `k3s_debug`                          | Enable debug logging on the k3s service.                                                       | `false`                        |
-| `k3s_registries`                     | Registries configuration file content.                                                         | `{ mirrors: {}, configs:{} }`  |
+| Variable                             | Description                                                                                | Default Value                  |
+|--------------------------------------|--------------------------------------------------------------------------------------------|--------------------------------|
+| `k3s_state`                          | State of k3s: installed, started, stopped, downloaded, uninstalled, validated.             | installed                      |
+| `k3s_release_version`                | Use a specific version of k3s, eg. `v0.2.0`. Specify `false` for stable.                   | `false`                        |
+| `k3s_config_file`                    | Location of the k3s configuration file.                                                    | `/etc/rancher/k3s/config.yaml` |
+| `k3s_build_cluster`                  | When multiple play hosts are available, attempt to cluster. Read notes below.              | `true`                         |
+| `k3s_registration_address`           | Fixed registration address for nodes. IP or FQDN.                                          | NULL                           |
+| `k3s_github_url`                     | Set the GitHub URL to install k3s from.                                                    | https://github.com/k3s-io/k3s  |
+| `k3s_install_dir`                    | Installation directory for k3s.                                                            | `/usr/local/bin`               |
+| `k3s_install_hard_links`             | Install using hard links rather than symbolic links.                                       | `false`                        |
+| `k3s_server_config_yaml_d_files`     | A flat list of templates to supplement the `k3s_server` configuration.                     | []                             |
+| `k3s_agent_config_yaml_d_files`      | A flat list of templates to supplement the `k3s_agent` configuration.                      | []                             |
+| `k3s_server_manifests_urls`          | A list of URLs to deploy on the primary control plane. Read notes below.                   | []                             |
+| `k3s_server_manifests_templates`     | A flat list of templates to deploy on the primary control plane.                           | []                             |
+| `k3s_server_pod_manifests_urls`      | A list of URLs for installing static pod manifests on the control plane. Read notes below. | []                             |
+| `k3s_server_pod_manifests_templates` | A flat list of templates for installing static pod manifests on the control plane.         | []                             |
+| `k3s_use_experimental`               | Allow the use of experimental features in k3s.                                             | `false`                        |
+| `k3s_use_unsupported_config`         | Allow the use of unsupported configurations in k3s.                                        | `false`                        |
+| `k3s_etcd_datastore`                 | Enable etcd embedded datastore (read notes below).                                         | `false`                        |
+| `k3s_debug`                          | Enable debug logging on the k3s service.                                                   | `false`                        |
+| `k3s_registries`                     | Registries configuration file content.                                                     | `{ mirrors: {}, configs:{} }`  |
 
 ### K3S Service Configuration
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -12,8 +12,11 @@ k3s_state: installed
 # k3s_release_version: v1.19.3
 k3s_release_version: false
 
-# Loction of the k3s configuration file
-k3s_config_file: /etc/rancher/k3s/config.yaml
+# Location of the k3s configuration file
+k3s_config_file: "/etc/rancher/k3s/config.yaml"
+
+# Location of the k3s configuration directory
+k3s_config_yaml_d_dir: "/etc/rancher/k3s/config.yaml.d"
 
 # When multiple ansible_play_hosts are present, attempt to cluster the nodes.
 # Using false will create multiple standalone nodes.
@@ -35,10 +38,16 @@ k3s_install_dir: /usr/local/bin
 # Install using hard links rather than symbolic links
 k3s_install_hard_links: false
 
-# A list of templates used for preconfigure the cluster.
+# A list of templates used for configuring the server.
+k3s_server_config_yaml_d_files: []
+
+# A list of templates used for configuring the agent.
+k3s_agent_config_yaml_d_files: []
+
+# A list of templates used for pre-configuring the cluster.
 k3s_server_manifests_templates: []
 
-# A list of URLs used for preconfigure the cluster.
+# A list of URLs used for pre-configuring the cluster.
 k3s_server_manifests_urls: []
 #  - url: https://some/url/to/manifest.yml
 #    filename: manifest.yml

--- a/tasks/build/preconfigure-k3s-agent-config-yaml-d.yml
+++ b/tasks/build/preconfigure-k3s-agent-config-yaml-d.yml
@@ -1,0 +1,18 @@
+---
+
+- name: Ensure that the config.yaml.d directory exists
+  ansible.builtin.file:
+    state: directory
+    path: "{{ k3s_config_yaml_d_dir }}"
+    mode: 0755
+  when: k3s_agent_config_yaml_d_files | length > 0
+  become: "{{ k3s_become_for_directory_creation | ternary(true, false, k3s_become_for_all) }}"
+
+# https://github.com/k3s-io/k3s/pull/1691
+- name: Ensure configuration files are copied to controllers
+  ansible.builtin.template:
+    src: "{{ item }}"
+    dest: "{{ k3s_config_yaml_d_dir }}/{{ item | basename | replace('.j2','') }}"
+    mode: 0644
+  loop: "{{ k3s_agent_config_yaml_d_files }}"
+  become: "{{ k3s_become_for_directory_creation | ternary(true, false, k3s_become_for_all) }}"

--- a/tasks/build/preconfigure-k3s-agent-config-yaml-d.yml
+++ b/tasks/build/preconfigure-k3s-agent-config-yaml-d.yml
@@ -9,7 +9,7 @@
   become: "{{ k3s_become_for_directory_creation | ternary(true, false, k3s_become_for_all) }}"
 
 # https://github.com/k3s-io/k3s/pull/1691
-- name: Ensure configuration files are copied to controllers
+- name: Ensure configuration files are copied to agents
   ansible.builtin.template:
     src: "{{ item }}"
     dest: "{{ k3s_config_yaml_d_dir }}/{{ item | basename | replace('.j2','') }}"

--- a/tasks/build/preconfigure-k3s-server-config-yaml-d.yml
+++ b/tasks/build/preconfigure-k3s-server-config-yaml-d.yml
@@ -1,0 +1,18 @@
+---
+
+- name: Ensure that the config.yaml.d directory exists
+  ansible.builtin.file:
+    state: directory
+    path: "{{ k3s_config_yaml_d_dir }}"
+    mode: 0755
+  when: k3s_server_config_yaml_d_files | length > 0
+  become: "{{ k3s_become_for_directory_creation | ternary(true, false, k3s_become_for_all) }}"
+
+# https://github.com/k3s-io/k3s/pull/1691
+- name: Ensure configuration files are copied to controllers
+  ansible.builtin.template:
+    src: "{{ item }}"
+    dest: "{{ k3s_config_yaml_d_dir }}/{{ item | basename | replace('.j2','') }}"
+    mode: 0644
+  loop: "{{ k3s_server_config_yaml_d_files }}"
+  become: "{{ k3s_become_for_directory_creation | ternary(true, false, k3s_become_for_all) }}"

--- a/tasks/state-installed.yml
+++ b/tasks/state-installed.yml
@@ -54,6 +54,16 @@
     - k3s_control_node
     - k3s_server_pod_manifests_urls | length > 0
 
+- import_tasks: build/preconfigure-k3s-server-config-yaml-d.yml
+  when:
+    - k3s_control_node
+    - k3s_server_config_yaml_d_files | length > 0
+
+- import_tasks: build/preconfigure-k3s-agent-config-yaml-d.yml
+  when:
+    - not k3s_control_node
+    - k3s_agent_config_yaml_d_files | length > 0
+
 - import_tasks: build/install-k3s.yml
 
 - name: Ensure containerd installation tasks are run

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -74,7 +74,7 @@ k3s_systemd_unit_dir: "/etc/systemd/{{ k3s_systemd_context }}"
 # Data directory location for k3s
 k3s_data_dir: "{{ k3s_runtime_config['data-dir'] | default('/var/lib/rancher/k3s') }}"
 
-# Config directroy location for k3s
+# Config directory location for k3s
 k3s_config_dir: "{{ k3s_config_file | dirname }}"
 
 # Directory for gathering the k3s token for clustering. I don't see this changing.
@@ -99,6 +99,8 @@ k3s_check_packages: []
 k3s_ensure_directories_exist:
   - name: Config directory
     path: "{{ k3s_config_dir }}"
+  - name: Config.yaml.d directory
+    path: "{{ k3s_config_yaml_d_dir }}"
   - name: Systemd unit file directory
     path: "{{ k3s_systemd_unit_dir }}"
   - name: Data directory


### PR DESCRIPTION
## feat: implement config.yaml.d

### Summary

Implements 2 new variables that can configure k3s settings with adding files to the `config.yaml.d` directory.

There are two variables that will allow for customizing the server or agents

```
# A list of templates used for configuring the server.
k3s_server_config_yaml_d_files: []

# A list of templates used for configuring the agent.
k3s_agent_config_yaml_d_files: []
```

Fixes https://github.com/PyratLabs/ansible-role-k3s/issues/148

### Issue type

- Feature

### Test instructions

Add templates to the above variables with k3s server or agent configuration options.

### Acceptance Criteria

<!-- Please list criteria required to ensure this change has been sufficiently reviewed.  -->

- [x] Documentation updated.

