### PR TITLE
Added option to chnage K3s updates API url

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -26,6 +26,9 @@ k3s_build_cluster: true
 # URL for GitHub project
 k3s_github_url: https://github.com/k3s-io/k3s
 
+# URL for K3s updates API
+k3s_api_url: https://update.k3s.io
+
 # Skip all tasks that validate configuration
 k3s_skip_validation: false
 

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -51,7 +51,7 @@ k3s_arch_lookup:
 k3s_release_channel: stable
 
 # K3s updates API
-k3s_api_releases: https://update.k3s.io/v1-release/channels
+k3s_api_releases: "{{ k3s_api_url }}/v1-release/channels"
 # Download location for releases
 k3s_github_download_url: "{{ k3s_github_url }}/releases/download"
 


### PR DESCRIPTION
## Added option to chnage K3s updates API url

### Summary

Sometimes it's needed to change different URL's, when there are no dirrect access to internet. In these cases is good to replace URL's with proxy URL's.