### PR TITLE
Feature: Air Gap Installation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,7 @@ jobs:
 
       - name: Run Molecule tests
         run: molecule test --scenario-name "${{ matrix.scenario }}"
+        continue-on-error: true
         env:
           PY_COLORS: '1'
           ANSIBLE_FORCE_COLOR: '1'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
             scenario: highavailabilitydb
           - distro: fedora31
             scenario: autodeploy
-          - distro: debian9
+          - distro: debian11
             scenario: highavailabilityetcd
           - distro: rockylinux8
             scenario: highavailabilityetcd

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,7 @@ jobs:
 
       - name: Run Molecule tests
         run: molecule test --scenario-name "${{ matrix.scenario }}"
-        continue-on-error: true
+        # continue-on-error: true
         env:
           PY_COLORS: '1'
           ANSIBLE_FORCE_COLOR: '1'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,18 @@
 ---
 -->
 
+## 2021-12-23, v2.12.1
+
+### Notable changes
+
+  - Fix typo in systemd unit file
+
+### Contributors
+
+  - [andrewchen5678](https://github.com/andrewchen5678)
+
+---
+
 ## 2021-12-20, v2.12.0
 
 ### Notable changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,26 @@
 ---
 -->
 
+## 2021-12-20, v2.12.0
+
+### Notable changes
+
+  - Fix RockyLinux HA etcd tests
+  - add Debian 11 test
+  - Fix Snapshotter in Molecule tests
+  - Added missing documentation for `k3s_api_url`
+  - Added option to change K3s updates API url
+  - Custom environment variables in systemd unit files
+  - Debian Bullseye support
+  - Fix HA etcd cluster startup
+  - Fix rootless for Debian
+
+### Contributors
+
+  - [janar153](https://github.com/janar153)
+
+---
+
 ## 2021-10-10, v2.11.1
 
 ### Notable changes

--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ consistency. These are generally cluster-level configuration.
 | `k3s_build_cluster`                  | When multiple play hosts are available, attempt to cluster. Read notes below.              | `true`                         |
 | `k3s_registration_address`           | Fixed registration address for nodes. IP or FQDN.                                          | NULL                           |
 | `k3s_github_url`                     | Set the GitHub URL to install k3s from.                                                    | https://github.com/k3s-io/k3s  |
+| `k3s_api_url`                        | URL for K3S updates API.                                                                   | https://update.k3s.io          |
 | `k3s_install_dir`                    | Installation directory for k3s.                                                            | `/usr/local/bin`               |
 | `k3s_install_hard_links`             | Install using hard links rather than symbolic links.                                       | `false`                        |
 | `k3s_server_config_yaml_d_files`     | A flat list of templates to supplement the `k3s_server` configuration.                     | []                             |

--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ consistency. These are generally cluster-level configuration.
 |--------------------------------------|--------------------------------------------------------------------------------------------|--------------------------------|
 | `k3s_state`                          | State of k3s: installed, started, stopped, downloaded, uninstalled, validated.             | installed                      |
 | `k3s_release_version`                | Use a specific version of k3s, eg. `v0.2.0`. Specify `false` for stable.                   | `false`                        |
+| `k3s_airgap`                         | Boolean to enable air-gapped installations                                                 | `false`                        |
 | `k3s_config_file`                    | Location of the k3s configuration file.                                                    | `/etc/rancher/k3s/config.yaml` |
 | `k3s_build_cluster`                  | When multiple play hosts are available, attempt to cluster. Read notes below.              | `true`                         |
 | `k3s_registration_address`           | Fixed registration address for nodes. IP or FQDN.                                          | NULL                           |
@@ -316,6 +317,10 @@ k3s_server_pod_manifests_urls:
     filename: kube-vip.yaml
 
 ```
+
+#### Important note about `k3s_airgap`
+
+When deploying k3s in an air gapped environment you should provide the `k3s` binary in `./files/`. The binary will not be downloaded from Github and will subsequently not be verified using the provided sha256 sum, nor able to verify the version that you are running. All risks and burdens associated are assumed by the user in this scenario.
 
 ## Dependencies
 

--- a/README.md
+++ b/README.md
@@ -89,16 +89,22 @@ The below variables change how and when the systemd service unit file for K3S
 is run. Use this with caution, please refer to the [systemd documentation](https://www.freedesktop.org/software/systemd/man/systemd.unit.html#%5BUnit%5D%20Section%20Options)
 for more information.
 
-| Variable               | Description                                                    | Default Value |
-|------------------------|----------------------------------------------------------------|---------------|
-| `k3s_start_on_boot`    | Start k3s on boot.                                             | `true`        |
-| `k3s_service_requires` | List of required systemd units to k3s service unit.            | []            |
-| `k3s_service_wants`    | List of "wanted" systemd unit to k3s (weaker than "requires"). | []\*          |
-| `k3s_service_before`   | Start k3s before a defined list of systemd units.              | []            |
-| `k3s_service_after`    | Start k3s after a defined list of systemd units.               | []\*          |
+| Variable               | Description                                                          | Default Value |
+|------------------------|----------------------------------------------------------------------|---------------|
+| `k3s_start_on_boot`    | Start k3s on boot.                                                   | `true`        |
+| `k3s_service_requires` | List of required systemd units to k3s service unit.                  | []            |
+| `k3s_service_wants`    | List of "wanted" systemd unit to k3s (weaker than "requires").       | []\*          |
+| `k3s_service_before`   | Start k3s before a defined list of systemd units.                    | []            |
+| `k3s_service_after`    | Start k3s after a defined list of systemd units.                     | []\*          |
+| `k3s_service_env_vars` | Dictionary of environment variables to use within systemd unit file. | {}            |
+| `k3s_service_env_file` | Location on host of a environment file to include.                   | `false`\*\*   |
 
 \* The systemd unit template **always** specifies `network-online.target` for
 `wants` and `after`.
+
+\*\* The file must already exist on the target host, this role will not create
+nor manage the file. You can manage this file outside of the role with
+pre-tasks in your Ansible playbook.
 
 ### Group/Host Variables
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -91,6 +91,17 @@ k3s_service_before: []
 # Start k3s after a defined list of systemd units.
 k3s_service_after: []
 
+# Dictionary of environment variables to use within systemd unit file
+# Some examples below
+k3s_service_env_vars: {}
+#  PATH: /opt/k3s/bin
+#  GOGC: 10
+
+# Location on host of a environment file to include. This must already exist on
+# the target as this role will not populate this file.
+k3s_service_env_file: false
+
+
 ##
 # Server Configuration
 ##

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -26,6 +26,9 @@ k3s_build_cluster: true
 # URL for GitHub project
 k3s_github_url: https://github.com/k3s-io/k3s
 
+# URL for K3s updates API
+k3s_api_url: https://update.k3s.io
+
 # Skip all tasks that validate configuration
 k3s_skip_validation: false
 

--- a/molecule/autodeploy/converge.yml
+++ b/molecule/autodeploy/converge.yml
@@ -18,5 +18,7 @@
     k3s_server_manifests_urls:
       - url: https://raw.githubusercontent.com/metallb/metallb/v0.9.6/manifests/namespace.yaml
         filename: 05-metallb-namespace.yml
+    k3s_service_env_vars:
+      GOGC: 10
   roles:
     - role: "{{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY') | basename }}"

--- a/molecule/autodeploy/converge.yml
+++ b/molecule/autodeploy/converge.yml
@@ -11,6 +11,8 @@
     k3s_server:
       data-dir: /var/lib/k3s-io
       default-local-storage-path: /var/lib/k3s-io/local-storage
+    k3s_agent:
+      snapshotter: native
     k3s_server_manifests_templates:
       - "molecule/autodeploy/templates/00-ns-monitoring.yml.j2"
     k3s_server_manifests_urls:

--- a/molecule/autodeploy/prepare.yml
+++ b/molecule/autodeploy/prepare.yml
@@ -3,8 +3,10 @@
   hosts: node*
   become: true
   tasks:
-    - name: Ensure apt cache is updated
+    - name: Ensure apt cache is updated and iptables is installed
       ansible.builtin.apt:
+        name: iptables
+        state: present
         update_cache: true
       when: ansible_pkg_mgr == 'apt'
 

--- a/molecule/debug/converge.yml
+++ b/molecule/debug/converge.yml
@@ -4,6 +4,8 @@
   become: true
   vars:
     pyratlabs_issue_controller_dump: true
+    k3s_agent:
+      snapshotter: native
   pre_tasks:
     - name: Ensure k3s_debug is set
       ansible.builtin.set_fact:

--- a/molecule/debug/prepare.yml
+++ b/molecule/debug/prepare.yml
@@ -2,7 +2,9 @@
 - name: Prepare
   hosts: all
   tasks:
-    - name: Ensure apt cache is updated
+    - name: Ensure apt cache is updated and iptables is installed
       ansible.builtin.apt:
+        name: iptables
+        state: present
         update_cache: true
       when: ansible_pkg_mgr == 'apt'

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -8,3 +8,5 @@
         molecule_is_test: true
         k3s_install_hard_links: true
         k3s_release_version: stable
+        k3s_agent:
+          snapshotter: native

--- a/molecule/default/prepare.yml
+++ b/molecule/default/prepare.yml
@@ -2,7 +2,9 @@
 - name: Prepare
   hosts: all
   tasks:
-    - name: Ensure apt cache is updated
+    - name: Ensure apt cache is updated and iptables is installed
       ansible.builtin.apt:
+        name: iptables
+        state: present
         update_cache: true
       when: ansible_pkg_mgr == 'apt'

--- a/molecule/docker/converge.yml
+++ b/molecule/docker/converge.yml
@@ -9,5 +9,6 @@
       cluster-domain: examplecluster.local
     k3s_agent:
       docker: true
+      snapshotter: native
   roles:
     - role: "{{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY') | basename }}"

--- a/molecule/docker/prepare.yml
+++ b/molecule/docker/prepare.yml
@@ -2,7 +2,9 @@
 - name: Prepare
   hosts: all
   tasks:
-    - name: Ensure apt cache is updated
+    - name: Ensure apt cache is updated and iptables is installed
       ansible.builtin.apt:
+        name: iptables
+        state: present
         update_cache: true
       when: ansible_pkg_mgr == 'apt'

--- a/molecule/highavailabilitydb/converge.yml
+++ b/molecule/highavailabilitydb/converge.yml
@@ -8,6 +8,8 @@
     k3s_registration_address: loadbalancer
     k3s_server:
       datastore-endpoint: "postgres://postgres:verybadpass@database:5432/postgres?sslmode=disable"
+    k3s_agent:
+      snapshotter: native
   pre_tasks:
     - name: Set each node to be a control node
       ansible.builtin.set_fact:

--- a/molecule/highavailabilitydb/converge.yml
+++ b/molecule/highavailabilitydb/converge.yml
@@ -10,6 +10,7 @@
       datastore-endpoint: "postgres://postgres:verybadpass@database:5432/postgres?sslmode=disable"
     k3s_agent:
       snapshotter: native
+    k3s_service_env_file: /tmp/k3s.env
   pre_tasks:
     - name: Set each node to be a control node
       ansible.builtin.set_fact:

--- a/molecule/highavailabilitydb/prepare.yml
+++ b/molecule/highavailabilitydb/prepare.yml
@@ -43,3 +43,4 @@
         path: /tmp/k3s.env
         line: "THISHOST={{ ansible_hostname }}"
         mode: 0644
+        create: true

--- a/molecule/highavailabilitydb/prepare.yml
+++ b/molecule/highavailabilitydb/prepare.yml
@@ -33,8 +33,10 @@
 - name: Prepare nodes
   hosts: node*
   tasks:
-    - name: Ensure apt cache is updated
+    - name: Ensure apt cache is updated and iptables is installed
       ansible.builtin.apt:
+        name: iptables
+        state: present
         update_cache: true
       when: ansible_pkg_mgr == 'apt'
 

--- a/molecule/highavailabilitydb/prepare.yml
+++ b/molecule/highavailabilitydb/prepare.yml
@@ -37,3 +37,9 @@
       ansible.builtin.apt:
         update_cache: true
       when: ansible_pkg_mgr == 'apt'
+
+    - name: Ensure environment file exists for k3s_service_env_file
+      ansible.builtin.lineinfile:
+        path: /tmp/k3s.env
+        line: "THISHOST={{ ansible_hostname }}"
+        mode: 0644

--- a/molecule/highavailabilityetcd/converge.yml
+++ b/molecule/highavailabilityetcd/converge.yml
@@ -11,6 +11,7 @@
       secrets-encryption: true
     k3s_agent:
       node-ip: "{{ ansible_default_ipv4.address }}"
+      snapshotter: native
   pre_tasks:
     - name: Set each node to be a control node
       ansible.builtin.set_fact:

--- a/molecule/highavailabilityetcd/prepare.yml
+++ b/molecule/highavailabilityetcd/prepare.yml
@@ -33,8 +33,10 @@
 - name: Prepare nodes
   hosts: node*
   tasks:
-    - name: Ensure apt cache is updated
+    - name: Ensure apt cache is updated and iptables is installed
       ansible.builtin.apt:
+        name: iptables
+        state: present
         update_cache: true
       when: ansible_pkg_mgr == 'apt'
 

--- a/molecule/highavailabilityetcd/prepare.yml
+++ b/molecule/highavailabilityetcd/prepare.yml
@@ -37,3 +37,10 @@
       ansible.builtin.apt:
         update_cache: true
       when: ansible_pkg_mgr == 'apt'
+
+    - name: Ensure iproute is installed
+      ansible.builtin.dnf:
+        name: iproute
+        state: present
+        update_cache: true
+      when: ansible_pkg_mgr == 'dnf'

--- a/molecule/nodeploy/k3s_agent.yml
+++ b/molecule/nodeploy/k3s_agent.yml
@@ -6,3 +6,4 @@ node-label:
 kubelet-arg:
   - "cloud-provider=external"
   - "provider-id=azure"
+snapshotter: native

--- a/molecule/nodeploy/prepare.yml
+++ b/molecule/nodeploy/prepare.yml
@@ -2,7 +2,9 @@
 - name: Prepare
   hosts: all
   tasks:
-    - name: Ensure apt cache is updated
+    - name: Ensure apt cache is updated and iptables is installed
       ansible.builtin.apt:
+        name: iptables
+        state: present
         update_cache: true
       when: ansible_pkg_mgr == 'apt'

--- a/tasks/build/airgap-k3s.yml
+++ b/tasks/build/airgap-k3s.yml
@@ -9,6 +9,7 @@
 - name: Ensure k3s binary is downloaded
   ansible.builtin.copy:
     src: k3s
-    dest: "{{ k3s_install_dir }}/k3s"
+    # TODO: allow airgap to bypass version post-fix
+    dest: "{{ k3s_install_dir }}/k3s-{{ k3s_release_version }}"
     mode: 0755
   become: "{{ k3s_become_for_install_dir | ternary(true, false, k3s_become_for_all)  }}"

--- a/tasks/build/airgap-k3s.yml
+++ b/tasks/build/airgap-k3s.yml
@@ -6,7 +6,7 @@
     state: directory
     mode: 0755
 
-- name: Ensure k3s binary is downloaded
+- name: Copy local k3s binary to target host
   ansible.builtin.copy:
     src: k3s
     # TODO: allow airgap to bypass version post-fix

--- a/tasks/build/airgap-k3s.yml
+++ b/tasks/build/airgap-k3s.yml
@@ -1,0 +1,14 @@
+---
+
+- name: Ensure installation directory exists
+  ansible.builtin.file:
+    path: "{{ k3s_install_dir }}"
+    state: directory
+    mode: 0755
+
+- name: Ensure k3s binary is downloaded
+  ansible.builtin.copy:
+    src: k3s
+    dest: "{{ k3s_install_dir }}/k3s"
+    mode: 0755
+  become: "{{ k3s_become_for_install_dir | ternary(true, false, k3s_become_for_all)  }}"

--- a/tasks/build/docker/debian/install-prerequisites.yml
+++ b/tasks/build/docker/debian/install-prerequisites.yml
@@ -6,7 +6,7 @@
       - apt-transport-https
       - ca-certificates
       - curl
-      - "{{ 'gnupg2' if ansible_distribution == 'Debian' else 'gnupg-agent' }}"
+      - "{{ 'gnupg2' if k3s_os_distribution == 'debian' else 'gnupg-agent' }}"
       - software-properties-common
     state: present
   register: ensure_docker_prerequisites_installed
@@ -17,13 +17,13 @@
 
 - name: Ensure Docker APT key is present
   ansible.builtin.apt_key:
-    url: https://download.docker.com/linux/{{ ansible_distribution | lower }}/gpg
+    url: https://download.docker.com/linux/{{ k3s_os_distribution }}/gpg
     state: present
   become: "{{ k3s_become_for_package_install | ternary(true, false, k3s_become_for_all) }}"
 
 - name: Ensure Docker repository is installed and configured
   ansible.builtin.apt_repository:
     filename: docker-ce
-    repo: "deb https://download.docker.com/linux/{{ ansible_distribution | lower }} {{ ansible_distribution_release }} stable"
+    repo: "deb https://download.docker.com/linux/{{ k3s_os_distribution }} {{ ansible_distribution_release }} stable"
     update_cache: true
   become: "{{ k3s_become_for_package_install | ternary(true, false, k3s_become_for_all) }}"

--- a/tasks/build/docker/redhat/install-prerequisites.yml
+++ b/tasks/build/docker/redhat/install-prerequisites.yml
@@ -26,7 +26,7 @@
 
 - name: Check to see if Docker repository is available for this distribution
   ansible.builtin.uri:
-    url: "https://download.docker.com/linux/{{ ansible_distribution | lower }}/{{ ansible_distribution_major_version }}"
+    url: "https://download.docker.com/linux/{{ k3s_os_distribution }}/{{ ansible_distribution_major_version }}"
   register: k3s_redhat_repo_check
   failed_when: false
   changed_when: false
@@ -35,13 +35,13 @@
   ansible.builtin.yum_repository:
     name: docker-ce
     description: Docker CE Repository
-    baseurl: https://download.docker.com/linux/{{ ansible_distribution | lower }}/{{ ansible_distribution_major_version }}/$basearch/stable
-    gpgkey: https://download.docker.com/linux/{{ ansible_distribution | lower }}/gpg
+    baseurl: https://download.docker.com/linux/{{ k3s_os_distribution }}/{{ ansible_distribution_major_version }}/$basearch/stable
+    gpgkey: https://download.docker.com/linux/{{ k3s_os_distribution }}/gpg
     enabled: true
     gpgcheck: true
     state: present
   when:
-    - ansible_distribution | lower not in ['amazon']
+    - k3s_os_distribution not in ['amazon']
     - k3s_redhat_repo_check.status == 200
   become: "{{ k3s_become_for_package_install | ternary(true, false, k3s_become_for_all) }}"
 
@@ -51,6 +51,6 @@
   args:
     creates: /etc/yum.repos.d/docker-ce.repo
   when:
-    - ansible_distribution | lower not in ['amazon']
+    - k3s_os_distribution not in ['amazon']
     - k3s_redhat_repo_check.status != 200
   become: "{{ k3s_become_for_package_install | ternary(true, false, k3s_become_for_all) }}"

--- a/tasks/build/get-version.yml
+++ b/tasks/build/get-version.yml
@@ -1,5 +1,6 @@
 ---
 
+# TODO: Prevent or circumvent versioning when k3s_airgap
 - name: Ensure k3s_release_version is set to default if false
   ansible.builtin.set_fact:
     k3s_release_version: "{{ k3s_release_channel }}"

--- a/tasks/build/install-k3s.yml
+++ b/tasks/build/install-k3s.yml
@@ -17,6 +17,11 @@
 - include_tasks: install-k3s-node.yml
   when: k3s_build_cluster
 
+- name: Determine if the systems are already clustered
+  ansible.builtin.stat:
+    path: "{{ k3s_token_location }}"
+  register: k3s_token_cluster_check
+
 - name: Ensure k3s initial control plane server is started
   ansible.builtin.systemd:
     name: k3s
@@ -29,4 +34,5 @@
     - not ansible_check_mode
   when: (k3s_control_node and k3s_controller_list | length == 1)
         or (k3s_primary_control_node and k3s_controller_list | length > 1)
+        or k3s_token_cluster_check.stat.exists
   become: "{{ k3s_become_for_systemd | ternary(true, false, k3s_become_for_all) }}"

--- a/tasks/state-downloaded.yml
+++ b/tasks/state-downloaded.yml
@@ -4,3 +4,7 @@
   when: k3s_release_version is not defined or not k3s_release_version
 
 - import_tasks: build/download-k3s.yml
+  when: not k3s_airgap
+
+- import_tasks: build/airgap-k3s.yml
+  when: k3s_airgap

--- a/tasks/state-downloaded.yml
+++ b/tasks/state-downloaded.yml
@@ -1,7 +1,9 @@
 ---
 
 - import_tasks: build/get-version.yml
-  when: k3s_release_version is not defined or not k3s_release_version
+  when:
+    - k3s_release_version is not defined or not k3s_release_version
+    - not k3s_airgap
 
 - import_tasks: build/download-k3s.yml
   when: not k3s_airgap

--- a/tasks/state-installed.yml
+++ b/tasks/state-installed.yml
@@ -5,9 +5,11 @@
 - import_tasks: teardown/drain-and-remove-nodes.yml
 
 - import_tasks: build/get-version.yml
-  when: k3s_release_version is not defined
-        or not k3s_release_version
-        or k3s_release_version is not regex('\\+k3s[1-9]$')
+  when:
+    - k3s_release_version is not defined
+      or not k3s_release_version
+      or k3s_release_version is not regex('\\+k3s[1-9]$')
+    - not k3s_airgap
 
 - import_tasks: validate/main.yml
   when: not k3s_skip_validation

--- a/tasks/state-installed.yml
+++ b/tasks/state-installed.yml
@@ -33,6 +33,12 @@
   meta: flush_handlers
 
 - import_tasks: build/download-k3s.yml
+  when:
+    - not k3s_airgap
+
+- import_tasks: build/airgap-k3s.yml
+  when:
+    - k3s_airgap
 
 - import_tasks: build/preconfigure-k3s-auto-deploying-manifests.yml
   when:

--- a/tasks/state-installed.yml
+++ b/tasks/state-installed.yml
@@ -19,13 +19,13 @@
 - name: Ensure docker installation tasks are run
   block:
 
-    - include_tasks: build/docker/{{ ansible_os_family | lower }}/install-prerequisites.yml
+    - include_tasks: build/docker/{{ k3s_os_family }}/install-prerequisites.yml
 
     - import_tasks: build/docker/install.yml
-      when: ansible_distribution | replace(" ", "-") | lower not in ['amazon', 'suse', 'opensuse-leap', 'archlinux']
+      when: k3s_os_distribution not in ['amazon', 'suse', 'opensuse-leap', 'archlinux']
 
-    - include_tasks: build/docker/{{ ansible_distribution | replace(" ", "-") | lower }}/install.yml
-      when: ansible_distribution | replace(" ", "-") | lower in ['amazon', 'suse', 'opensuse-leap', 'archlinux']
+    - include_tasks: build/docker/{{ k3s_os_distribution }}/install.yml
+      when: k3s_os_distribution in ['amazon', 'suse', 'opensuse-leap', 'archlinux']
 
   when:
     - ('docker' in k3s_runtime_config and k3s_runtime_config.docker)

--- a/tasks/state-uninstalled.yml
+++ b/tasks/state-uninstalled.yml
@@ -10,12 +10,12 @@
   block:
 
     - import_tasks: teardown/docker/uninstall.yml
-      when: ansible_distribution | replace(" ", "-") | lower not in ['amazon', 'suse', 'opensuse-leap', 'archlinux']
+      when: k3s_os_distribution not in ['amazon', 'suse', 'opensuse-leap', 'archlinux']
 
-    - include_tasks: teardown/docker/{{ ansible_distribution | replace(" ", "-") | lower }}/uninstall.yml
-      when: ansible_distribution | replace(" ", "-") | lower in ['amazon', 'suse', 'opensuse-leap', 'archlinux']
+    - include_tasks: teardown/docker/{{ k3s_os_distribution }}/uninstall.yml
+      when: k3s_os_distribution in ['amazon', 'suse', 'opensuse-leap', 'archlinux']
 
-    - include_tasks: teardown/docker/{{ ansible_os_family | lower }}/uninstall-prerequisites.yml
+    - include_tasks: teardown/docker/{{ k3s_os_family }}/uninstall-prerequisites.yml
 
   when:
     - ('docker' in k3s_runtime_config and k3s_runtime_config.docker)

--- a/tasks/teardown/docker/debian/uninstall-prerequisites.yml
+++ b/tasks/teardown/docker/debian/uninstall-prerequisites.yml
@@ -3,13 +3,13 @@
 - name: Ensure Docker repository is uninstalled
   ansible.builtin.apt_repository:
     filename: docker-ce
-    repo: "deb https://download.docker.com/linux/{{ ansible_distribution | lower }} {{ ansible_distribution_release }} stable"
+    repo: "deb https://download.docker.com/linux/{{ k3s_os_distribution }} {{ ansible_distribution_release }} stable"
     update_cache: false
     state: absent
   become: "{{ k3s_become_for_uninstall | ternary(true, false, k3s_become_for_all) }}"
 
 - name: Ensure Docker APT key is uninstalled
   ansible.builtin.apt_key:
-    url: https://download.docker.com/linux/{{ ansible_distribution | lower }}/gpg
+    url: https://download.docker.com/linux/{{ k3s_os_distribution }}/gpg
     state: absent
   become: "{{ k3s_become_for_uninstall | ternary(true, false, k3s_become_for_all) }}"

--- a/tasks/teardown/docker/redhat/uninstall-prerequisites.yml
+++ b/tasks/teardown/docker/redhat/uninstall-prerequisites.yml
@@ -4,10 +4,10 @@
   ansible.builtin.yum_repository:
     name: docker-ce
     description: Docker CE Repository
-    baseurl: https://download.docker.com/linux/{{ ansible_distribution | lower }}/{{ ansible_distribution_major_version }}/$basearch/stable
-    gpgkey: https://download.docker.com/linux/{{ ansible_distribution | lower }}/gpg
+    baseurl: https://download.docker.com/linux/{{ k3s_os_distribution }}/{{ ansible_distribution_major_version }}/$basearch/stable
+    gpgkey: https://download.docker.com/linux/{{ k3s_os_distribution }}/gpg
     enabled: false
     gpgcheck: true
     state: absent
-  when: ansible_distribution | lower not in ['amazon']
+  when: k3s_os_distribution not in ['amazon']
   become: "{{ k3s_become_for_uninstall | ternary(true, false, k3s_become_for_all) }}"

--- a/tasks/validate/configuration/unsupported-rootless.yml
+++ b/tasks/validate/configuration/unsupported-rootless.yml
@@ -50,7 +50,7 @@
   ansible.builtin.assert:
     that:
       - k3s_get_unprivileged_userns_clone['content'] | b64decode | int == 1
-      - k3s_get_max_user_namespaces['content'] | b64decode | int >= 28633
+      - ((k3s_get_max_user_namespaces['content'] | b64decode | int >= 28633) or (k3s_os_family != "redhat"))
       - k3s_current_user_subuid != "UserNotFound:0:0"
       - k3s_current_user_subgid != "UserNotFound:0:0"
       - k3s_current_user_subuid.split(':')[2] | int >= 65536

--- a/tasks/validate/configuration/variables.yml
+++ b/tasks/validate/configuration/variables.yml
@@ -6,6 +6,7 @@
       - (k3s_release_version | replace('v', '')) is version_compare(k3s_min_version, '>=')
     success_msg: "{{ k3s_release_version }} is supported by this role."
     fail_msg: "{{ k3s_release_version }} is not supported by this role, please use xanmanning.k3s v1.x."
+  when: not k3s_airgap
 
 - name: Check configuration in k3s_server and k3s_agent that needs alternate configuration
   ansible.builtin.assert:
@@ -34,6 +35,7 @@
       {% endif %}
   loop: "{{ k3s_deprecated_config }}"
   when:
+    - not k3s_airgap
     - (item.when is not defined
        or (item.when is defined and (k3s_release_version | replace('v', '')) is version_compare(item.when, '>=')))
     - not k3s_use_unsupported_config

--- a/tasks/validate/environment/remote/packages.yml
+++ b/tasks/validate/environment/remote/packages.yml
@@ -18,7 +18,8 @@
       Documentation: {{ package.documentation }}
       {% endif %}
   when:
+    - check_k3s_required_package.rc is defined
     - (package.until is not defined
-       or k3s_release_version is version_compare(package.until, '>='))
+       or (k3s_release_version | replace('v', '')) is version_compare(package.until, '>='))
     - (package.from is not defined
-       or k3s_release_version is version_compare(package.from, '>='))
+       or (k3s_release_version | replace('v', '')) is version_compare(package.from, '>='))

--- a/tasks/validate/main.yml
+++ b/tasks/validate/main.yml
@@ -1,5 +1,14 @@
 ---
 
+- include_tasks: environment/remote/packages.yml
+  loop: "{{ k3s_check_packages[ansible_distribution | replace(' ', '-') | lower] }}"
+  loop_control:
+    loop_var: package
+  when:
+    - not k3s_skip_validation
+    - not k3s_skip_env_checks
+    - k3s_check_packages[ansible_distribution | replace(' ', '-') | lower] is defined
+
 - import_tasks: configuration/variables.yml
 
 - import_tasks: configuration/experimental-variables.yml

--- a/tasks/validate/main.yml
+++ b/tasks/validate/main.yml
@@ -1,13 +1,13 @@
 ---
 
 - include_tasks: environment/remote/packages.yml
-  loop: "{{ k3s_check_packages[ansible_distribution | replace(' ', '-') | lower] }}"
+  loop: "{{ k3s_check_packages[k3s_os_distribution_version] }}"
   loop_control:
     loop_var: package
   when:
     - not k3s_skip_validation
     - not k3s_skip_env_checks
-    - k3s_check_packages[ansible_distribution | replace(' ', '-') | lower] is defined
+    - k3s_check_packages[k3s_os_distribution_version] is defined
 
 - import_tasks: configuration/variables.yml
 

--- a/tasks/validate/pre-flight.yml
+++ b/tasks/validate/pre-flight.yml
@@ -21,14 +21,6 @@
     - not k3s_skip_validation
     - not k3s_skip_env_checks
 
-- include_tasks: environment/remote/packages.yml
-  loop: "{{ k3s_check_packages }}"
-  loop_control:
-    loop_var: package
-  when:
-    - not k3s_skip_validation
-    - not k3s_skip_env_checks
-
 - include_tasks: environment/local/issue-data.yml
   when:
     - pyratlabs_issue_controller_dump is defined

--- a/templates/k3s.service.j2
+++ b/templates/k3s.service.j2
@@ -19,8 +19,8 @@ After={{ after_unit }}
 [Service]
 Type={{ 'notify' if k3s_control_node else 'exec' }}
 {% if k3s_service_env_vars is defined and k3s_service_env_vars is iterable %}
-{% for env_var, env_value in k3s_service_env_vars %}
-Environent={{ env_var }}={{ env_value }}
+{% for env_var in k3s_service_env_vars %}
+Environent={{ env_var }}={{ k3s_service_env_vars[env_var] }}
 {% endfor %}
 {% endif %}
 {% if k3s_service_env_file is defined and k3s_service_env_file %}

--- a/templates/k3s.service.j2
+++ b/templates/k3s.service.j2
@@ -20,7 +20,7 @@ After={{ after_unit }}
 Type={{ 'notify' if k3s_control_node else 'exec' }}
 {% if k3s_service_env_vars is defined and k3s_service_env_vars is iterable %}
 {% for env_var in k3s_service_env_vars %}
-Environent={{ env_var }}={{ k3s_service_env_vars[env_var] }}
+Environment={{ env_var }}={{ k3s_service_env_vars[env_var] }}
 {% endfor %}
 {% endif %}
 {% if k3s_service_env_file is defined and k3s_service_env_file %}

--- a/templates/k3s.service.j2
+++ b/templates/k3s.service.j2
@@ -18,6 +18,14 @@ After={{ after_unit }}
 
 [Service]
 Type={{ 'notify' if k3s_control_node else 'exec' }}
+{% if k3s_service_env_vars is defined and k3s_service_env_vars is iterable %}
+{% for env_var, env_value in k3s_service_env_vars %}
+Environent={{ env_var }}={{ env_value }}
+{% endfor %}
+{% endif %}
+{% if k3s_service_env_file is defined and k3s_service_env_file %}
+EnvironmentFile={{ k3s_service_env_file }}
+{% endif %}
 ExecStartPre=-/sbin/modprobe br_netfilter
 ExecStartPre=-/sbin/modprobe overlay
 {% filter regex_replace('\s+', ' ') %}

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -95,6 +95,7 @@ k3s_server_pod_manifests_dir: "{{ k3s_data_dir }}/agent/pod-manifests"
 k3s_os_distribution: "{{ ansible_distribution | replace(' ', '-') | lower }}"
 k3s_os_version: "{{ ansible_distribution_version | replace([' ', '.'], '-') | lower }}"
 k3s_os_distribution_version: "{{ k3s_os_distribution }}-{{ k3s_os_version }}"
+k3s_os_family: "{{ ansible_os_family | replace(' ', '-') | lower }}"
 
 # Packages that we need to check are installed
 k3s_check_packages:

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -55,6 +55,11 @@ k3s_api_releases: https://update.k3s.io/v1-release/channels
 # Download location for releases
 k3s_github_download_url: "{{ k3s_github_url }}/releases/download"
 
+# Install K3s in Air Gapped scenarios
+k3s_airgap: "false"
+
+# k3s_airgap_binary_path: "{{ role_path }}/files/k3s"
+
 # Generate a runtime config dictionary for validation
 k3s_runtime_config: "{{ (k3s_server | default({})) | combine (k3s_agent | default({})) }}"
 

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -92,7 +92,12 @@ k3s_server_manifests_dir: "{{ k3s_data_dir }}/server/manifests"
 k3s_server_pod_manifests_dir: "{{ k3s_data_dir }}/agent/pod-manifests"
 
 # Packages that we need to check are installed
-k3s_check_packages: []
+k3s_check_packages:
+  debian:
+    - name: iptables
+      from: 1.19.2
+      until: 1.22.2
+      documentation: https://rancher.com/docs/k3s/latest/en/advanced/#enabling-legacy-iptables-on-raspbian-buster
 # - name: dummy
 #   from: 1.19.2
 #   until: 1.21.0

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -91,12 +91,17 @@ k3s_server_manifests_dir: "{{ k3s_data_dir }}/server/manifests"
 # https://github.com/k3s-io/k3s/pull/1691
 k3s_server_pod_manifests_dir: "{{ k3s_data_dir }}/agent/pod-manifests"
 
+# OS formatted strings
+k3s_os_distribution: "{{ ansible_distribution | replace(' ', '-') | lower }}"
+k3s_os_version: "{{ ansible_distribution_version | replace([' ', '.'], '-') | lower }}"
+k3s_os_distribution_version: "{{ k3s_os_distribution }}-{{ k3s_os_version }}"
+
 # Packages that we need to check are installed
 k3s_check_packages:
-  debian:
-    - name: iptables
+  debian-11:
+    - name: iptables-legacy
       from: 1.19.2
-      until: 1.22.2
+      # until: 1.22.2
       documentation: https://rancher.com/docs/k3s/latest/en/advanced/#enabling-legacy-iptables-on-raspbian-buster
 # - name: dummy
 #   from: 1.19.2

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -56,9 +56,7 @@ k3s_api_releases: https://update.k3s.io/v1-release/channels
 k3s_github_download_url: "{{ k3s_github_url }}/releases/download"
 
 # Install K3s in Air Gapped scenarios
-k3s_airgap: "false"
-
-# k3s_airgap_binary_path: "{{ role_path }}/files/k3s"
+k3s_airgap: false
 
 # Generate a runtime config dictionary for validation
 k3s_runtime_config: "{{ (k3s_server | default({})) | combine (k3s_agent | default({})) }}"

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -51,7 +51,7 @@ k3s_arch_lookup:
 k3s_release_channel: stable
 
 # K3s updates API
-k3s_api_releases: https://update.k3s.io/v1-release/channels
+k3s_api_releases: "{{ k3s_api_url }}/v1-release/channels"
 # Download location for releases
 k3s_github_download_url: "{{ k3s_github_url }}/releases/download"
 


### PR DESCRIPTION
## Air Gap Support
### Bring your own binary

### Summary

The aim of this feature is to support users who are unable to contact or download anything from Github in the middle of deploying their k3s cluster.

Setting the `k3s_airgap` var to `true` will expect the `k3s` binary to live in `files/k3s` as is the default behavior for the `ansible.builtin.copy` module.

### Issue type

<!-- Pick one below and delete the rest -->
- Feature

### Test instructions

Simply changing the `k3s_airgap` var to `true` and placing `k3s` binary in `files/` will allow you to run the role as expected, skipping steps that are normally reserved for version checking and sanity checking as it relates to downloading the binary.

### Acceptance Criteria

<!-- Please list criteria required to ensure this change has been sufficiently reviewed.  -->

  - [x] GitHub Actions Build passes.
  - [X] Documentation updated.
  - [ ] Tested in a real air gapped environment

### Additional Information

<!-- Include additional information to help people understand the change here -->

<!-- Paste verbatim command output below, e.g. before and after your change -->

```text

```
