### PR TITLE
Adding become to pre checks packages

### DIFF
--- a/tasks/pre_checks_packages.yml
+++ b/tasks/pre_checks_packages.yml
@@ -6,6 +6,7 @@
   changed_when: false
   failed_when: false
   register: check_k3s_required_package
+  become: "{{ k3s_become }}"
 
 - name: Test that checks for {{ package.name }} passed
   ansible.builtin.assert:


### PR DESCRIPTION
To make sure that system packages are found with `which` in
distributions like Debian for example.

Issue #171 