### PR TITLE
use basename of url for items in k3s_server_manifests_urls and k3s_se…

### DIFF
--- a/README.md
+++ b/README.md
@@ -338,7 +338,7 @@ to `true`.
 #### Important note about `k3s_server_manifests_urls` and `k3s_server_pod_manifests_urls`
 
 To deploy server manifests and server pod manifests from URL, you need to
-specify a `url` and a `filename`. Below is an example of how to deploy the
+specify a `url` and optionally a `filename` (if none provided basename is used). Below is an example of how to deploy the
 Tigera operator for Calico and kube-vip.
 
 ```yaml

--- a/tasks/ensure_k3s_auto_deploy.yml
+++ b/tasks/ensure_k3s_auto_deploy.yml
@@ -34,7 +34,7 @@
 - name: Ensure auto-deploying manifests are downloaded to the primary controller
   ansible.builtin.get_url:
     url: "{{ item.url }}"
-    dest: "{{ k3s_server_manifests_dir }}/{{ item.filename }}"
+    dest: "{{ k3s_server_manifests_dir }}/{{ item.filename | default(item.url | basename }}"
     mode: 0644
   loop: "{{ k3s_server_manifests_urls }}"
   become: "{{ k3s_become }}"
@@ -55,7 +55,7 @@
 - name: Ensure auto-deploying manifests are downloaded to the primary controller
   ansible.builtin.get_url:
     url: "{{ item.url }}"
-    dest: "{{ k3s_server_pod_manifests_dir }}/{{ item.filename }}"
+    dest: "{{ k3s_server_pod_manifests_dir }}/{{ item.filename | default(item.url | basename }}"
     mode: 0644
   loop: "{{ k3s_server_pod_manifests_urls }}"
   become: "{{ k3s_become }}"

--- a/tasks/ensure_k3s_auto_deploy.yml
+++ b/tasks/ensure_k3s_auto_deploy.yml
@@ -34,7 +34,7 @@
 - name: Ensure auto-deploying manifests are downloaded to the primary controller
   ansible.builtin.get_url:
     url: "{{ item.url }}"
-    dest: "{{ k3s_server_manifests_dir }}/{{ item.filename | default(item.url | basename }}"
+    dest: "{{ k3s_server_manifests_dir }}/{{ item.filename | default(item.url | basename) }}"
     mode: 0644
   loop: "{{ k3s_server_manifests_urls }}"
   become: "{{ k3s_become }}"

--- a/tasks/ensure_k3s_auto_deploy.yml
+++ b/tasks/ensure_k3s_auto_deploy.yml
@@ -55,7 +55,7 @@
 - name: Ensure auto-deploying manifests are downloaded to the primary controller
   ansible.builtin.get_url:
     url: "{{ item.url }}"
-    dest: "{{ k3s_server_pod_manifests_dir }}/{{ item.filename | default(item.url | basename }}"
+    dest: "{{ k3s_server_pod_manifests_dir }}/{{ item.filename | default(item.url | basename) }}"
     mode: 0644
   loop: "{{ k3s_server_pod_manifests_urls }}"
   become: "{{ k3s_become }}"


### PR DESCRIPTION
…rver_pod_manifests_urls if filename is not provided

Signed-off-by: Karsten Kosmala <kosmala@cosmocode.de>

## use basename for auto-deploy manifests

### Summary

If no filename is provided in k3s_server_manifests_urls or k3s_server_pod_manifests_urls use url basename filter to extract the filename.

### Issue type

- Feature

### Test instructions

Use this vars statement. ccm-networks_changed.yaml, ccm-networks_changed.yaml and hcloud-csi.yml should land in /var/lib/rancher/k3s/server/manifests/.
```
  vars:
    k3s_server_manifests_urls:
      - url: "https://raw.githubusercontent.com/hetznercloud/hcloud-cloud-controller-manager/master/deploy/ccm-networks.yaml"
        filename: ccm-network.yaml
      - url: "https://raw.githubusercontent.com/hetznercloud/hcloud-cloud-controller-manager/master/deploy/ccm-networks.yaml"
        filename: ccm-network_changed.yaml
      - url: "https://raw.githubusercontent.com/hetznercloud/csi-driver/v1.6.0/deploy/kubernetes/hcloud-csi.yml"
```

### Acceptance Criteria

  - [x] GitHub Actions Build passes.
  - [X] Documentation updated.