### PR TITLE
fix: Support nftables for Debian 11

### DIFF
--- a/tasks/pre_checks_packages.yml
+++ b/tasks/pre_checks_packages.yml
@@ -21,6 +21,6 @@
   when:
     - check_k3s_required_package.rc is defined
     - (package.until is not defined
-       or (k3s_release_version | replace('v', '')) is version_compare(package.until, '>='))
+       or (k3s_release_version | replace('v', '')) is version_compare(package.until, '<'))
     - (package.from is not defined
        or (k3s_release_version | replace('v', '')) is version_compare(package.from, '>='))

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -112,7 +112,7 @@ k3s_check_packages:
   debian-11:
     - name: iptables-legacy
       from: 1.19.2
-      # until: 1.22.2
+      until: 1.22.3
       documentation: https://rancher.com/docs/k3s/latest/en/advanced/#enabling-legacy-iptables-on-raspbian-buster
 # - name: dummy
 #   from: 1.19.2


### PR DESCRIPTION
## Support nftables for Debian 11

### Summary

<!-- Describe the change below, including rationale and design decisions -->

<!-- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Since v1.22.3+k3s1 nftables is supported by k3s according to this comment: https://github.com/k3s-io/k3s/issues/4188#issuecomment-963124378
Also fixed silly mistake in version check

### Issue type

- Bugfix

### Test instructions

<!-- Please provide instructions for testing this PR -->
Deployed cluster of 1 controller and 2 workers on Vagrant. On resulting cluster deployed following DaemonSet:

```yaml
apiVersion: apps/v1
kind: DaemonSet
metadata:
  name: ubuntu-debug
spec:
  selector:
    matchLabels:
      name: ubuntu-debug
  template:
    metadata:
      labels:
        name: ubuntu-debug
    spec:
      tolerations:
      - key: node-role.kubernetes.io/master
        operator: Exists
        effect: NoSchedule
      containers:
      - name: ubuntu-debug
        image: docker.io/library/ubuntu:latest
        command: ['sleep', '3600']
```

Then connected to one of the workers and successfully managed to ping pods on other nodes. 

### Acceptance Criteria

<!-- Please list criteria required to ensure this change has been sufficiently reviewed.  -->

<!-- Example ticklist:
  - [ ] GitHub Actions Build passes.
  - [ ] Documentation updated.
-->

### Additional Information

<!-- Include additional information to help people understand the change here -->

<!-- Paste verbatim command output below, e.g. before and after your change -->

```text

```
