### PR TITLE
Fix check for k3s_token_location

### DIFF
--- a/templates/k3s.service.j2
+++ b/templates/k3s.service.j2
@@ -42,7 +42,7 @@ ExecStart={{ k3s_install_dir }}/k3s
     {% if k3s_server is defined %}
         --config {{ k3s_config_file }}
     {% endif %}
-    {% if k3s_control_node and not k3s_primary_control_node %}
+    {% if k3s_token_location %}
         --token-file {{ k3s_token_location }}
     {% endif %}
 {% else %}


### PR DESCRIPTION
## Fix check for k3s_token_location

### Summary
This PR fixes the check for adding the token to the k3s service file. Bug description in #187
### Issue type
- Bugfix
