### PR TITLE
Adding tasks to download admin kubeconfig

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -18,6 +18,15 @@ k3s_config_file: "/etc/rancher/k3s/config.yaml"
 # Location of the k3s configuration directory
 k3s_config_yaml_d_dir: "/etc/rancher/k3s/config.yaml.d"
 
+# Download Kubernetes config file to the Ansible controller
+k3s_download_kubeconf: false
+
+# Name of the Kubernetes config file will be downloaded to the Ansible controller
+k3s_download_kubeconf_file_name: k3s.yaml
+
+# Destination directory where the Kubernetes config file will be downloaded to the Ansible controller
+k3s_download_kubeconf_path: /tmp
+
 # When multiple ansible_play_hosts are present, attempt to cluster the nodes.
 # Using false will create multiple standalone nodes.
 # (default: true)

--- a/tasks/download_kubeconfig.yml
+++ b/tasks/download_kubeconfig.yml
@@ -2,7 +2,7 @@
 
 - name: Download k3s kubeconfig to localhost
   ansible.builtin.fetch:
-    src: /etc/rancher/k3s/k3s.yaml
+    src: /{{ k3s_config_dir }}/k3s.yaml
     dest: "{{ k3s_download_kubeconf_path }}/{{ k3s_download_kubeconf_file_name }}"
     flat: yes
   delegate_to: "{{ k3s_control_delegate }}"

--- a/tasks/download_kubeconfig.yml
+++ b/tasks/download_kubeconfig.yml
@@ -1,21 +1,55 @@
 ---
-
-- name: Ensure k3s kubeconfig is downloaded to Ansible Controller
-  ansible.builtin.fetch:
-    src: /{{ k3s_config_dir }}/k3s.yaml
-    dest: "{{ k3s_download_kubeconf_path }}/{{ k3s_download_kubeconf_file_name }}"
-    flat: yes
-  delegate_to: "{{ k3s_control_delegate }}"
-  run_once: true
-  when:
-  - k3s_download_kubeconf | bool
-
-- name: Ensure loopback IP is replaced with control-plane address
-  ansible.builtin.replace:
+- name: Ensure destination k3s kubeconfig exists
+  stat:
     path: "{{ k3s_download_kubeconf_path }}/{{ k3s_download_kubeconf_file_name }}"
-    regexp: '127.0.0.1'
-    replace: "{{ k3s_registration_address | default(hostvars[k3s_control_delegate].ansible_host) }}"
+  register: kubeconfig_local_file
   delegate_to: localhost
-  become: false
-  when:
-  - k3s_download_kubeconf | bool
+
+- name: Get remote k3s kubeconfig
+  ansible.builtin.slurp:
+    src: "{{ k3s_config_dir }}/k3s.yaml"
+  delegate_to: "{{ k3s_control_delegate }}"
+  register: remote_kubeconfig
+
+- name: Get local k3s kubeconfig
+  ansible.builtin.slurp:
+    src: "{{ k3s_download_kubeconf_path }}/{{ k3s_download_kubeconf_file_name }}"
+  delegate_to: localhost
+  register: local_kubeconfig
+  when: kubeconfig_local_file.stat.exists
+
+- name: Save client certificate data from remote k3s kubeconfig
+  ansible.builtin.set_fact:
+    remote_cert_data: "{{ remote_kubeconfig['content'] | b64decode | regex_search('(?<=client-certificate-data: ).*') }}"
+  when: remote_kubeconfig['content'] is defined
+
+- name: Save client certificate data from local k3s kubeconfig
+  ansible.builtin.set_fact:
+    local_cert_data: "{{ local_kubeconfig['content'] | b64decode | regex_search('(?<=client-certificate-data: ).*') }}"
+  when: local_kubeconfig['content'] is defined
+
+- name: Replase local kubeconfig
+  block:
+  - name: Ensure destination directory exists
+    ansible.builtin.file:
+      path: "{{ k3s_download_kubeconf_path }}"
+      state: directory
+      mode: 0755
+    delegate_to: localhost
+
+  - name: Ensure k3s kubeconfig is downloaded to Ansible Controller
+    ansible.builtin.fetch:
+      src: "{{ k3s_config_dir }}/k3s.yaml"
+      dest: "{{ k3s_download_kubeconf_path }}/{{ k3s_download_kubeconf_file_name }}"
+      flat: yes
+    delegate_to: "{{ k3s_control_delegate }}"
+    run_once: true
+
+  - name: Ensure loopback IP is replaced with control-plane address
+    ansible.builtin.replace:
+      path: "{{ k3s_download_kubeconf_path }}/{{ k3s_download_kubeconf_file_name }}"
+      regexp: '127.0.0.1'
+      replace: "{{ k3s_registration_address | default(hostvars[k3s_control_delegate].ansible_host) }}"
+    delegate_to: localhost
+  when: 
+   - local_cert_data is not defined or remote_cert_data != local_cert_data

--- a/tasks/download_kubeconfig.yml
+++ b/tasks/download_kubeconfig.yml
@@ -1,6 +1,6 @@
 ---
 - name: Ensure destination k3s kubeconfig exists
-  stat:
+  ansible.builtin.stat:
     path: "{{ k3s_download_kubeconf_path }}/{{ k3s_download_kubeconf_file_name }}"
   register: kubeconfig_local_file
   delegate_to: localhost
@@ -29,6 +29,8 @@
   when: local_kubeconfig['content'] is defined
 
 - name: Replase local kubeconfig
+  when: 
+   - local_cert_data is not defined or remote_cert_data != local_cert_data
   block:
   - name: Ensure destination directory exists
     ansible.builtin.file:
@@ -51,5 +53,3 @@
       regexp: '127.0.0.1'
       replace: "{{ k3s_registration_address | default(hostvars[k3s_control_delegate].ansible_host) }}"
     delegate_to: localhost
-  when: 
-   - local_cert_data is not defined or remote_cert_data != local_cert_data

--- a/tasks/download_kubeconfig.yml
+++ b/tasks/download_kubeconfig.yml
@@ -1,0 +1,21 @@
+---
+
+- name: Download k3s kubeconfig to localhost
+  ansible.builtin.fetch:
+    src: /etc/rancher/k3s/k3s.yaml
+    dest: "{{ k3s_download_kubeconf_path }}/{{ k3s_download_kubeconf_file_name }}"
+    flat: yes
+  delegate_to: "{{ k3s_control_delegate }}"
+  run_once: true
+  when:
+  - k3s_download_kubeconf | bool
+
+- name: Replace loopback IP by master server IP
+  ansible.builtin.replace:
+    path: "{{ k3s_download_kubeconf_path }}/{{ k3s_download_kubeconf_file_name }}"
+    regexp: '127.0.0.1'
+    replace: "{{ k3s_registration_address | default(hostvars[k3s_control_delegate].ansible_host) }}"
+  delegate_to: localhost
+  become: false
+  when:
+  - k3s_download_kubeconf | bool

--- a/tasks/download_kubeconfig.yml
+++ b/tasks/download_kubeconfig.yml
@@ -10,7 +10,7 @@
   when:
   - k3s_download_kubeconf | bool
 
-- name: Replace loopback IP by master server IP
+- name: Ensure loopback IP is replaced with control-plane address
   ansible.builtin.replace:
     path: "{{ k3s_download_kubeconf_path }}/{{ k3s_download_kubeconf_file_name }}"
     regexp: '127.0.0.1'

--- a/tasks/download_kubeconfig.yml
+++ b/tasks/download_kubeconfig.yml
@@ -1,6 +1,6 @@
 ---
 
-- name: Download k3s kubeconfig to localhost
+- name: Ensure k3s kubeconfig is downloaded to Ansible Controller
   ansible.builtin.fetch:
     src: /{{ k3s_config_dir }}/k3s.yaml
     dest: "{{ k3s_download_kubeconf_path }}/{{ k3s_download_kubeconf_file_name }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,4 +5,6 @@
 - include_tasks: state_{{ (k3s_state | lower) | default('installed') }}.yml
 
 - include_tasks: download_kubeconfig.yml
-  when: k3s_download_kubeconf | bool
+  when: 
+  - k3s_download_kubeconf | bool
+  - k3s_state != 'uninstalled'

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,3 +3,5 @@
 - import_tasks: pre_checks.yml
 
 - include_tasks: state_{{ (k3s_state | lower) | default('installed') }}.yml
+
+- include_tasks: download_kubeconfig.yml

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,3 +5,4 @@
 - include_tasks: state_{{ (k3s_state | lower) | default('installed') }}.yml
 
 - include_tasks: download_kubeconfig.yml
+  when: k3s_download_kubeconf | bool


### PR DESCRIPTION
## Download admin kubeconfig after installing a cluster

### Summary
It's nice to have the possibility to download admin kubeconfig at the end of the installation process. There aren't a lot of changes. Only 2 tasks and 3 help vars
If you think that some tasks or include should be in another place, move it

### Issue type
- Feature

### Test instructions

Run a playbook with the next vars:
```
    k3s_download_kubeconf: true
    k3s_download_kubeconf_file_name: name_of_config.yaml # Optional
    k3s_download_kubeconf_path: /path/to/config/folder # Optional
``` 

### Additional Information
Also works with - "k3s_registration_address" variable. If set, IP or FQDN, the replace task takes data from it for the kubeconfig server address directive