### PR TITLE
Fixes #197 fix length indentation in registry.yaml

### DIFF
--- a/templates/registries.yaml.j2
+++ b/templates/registries.yaml.j2
@@ -1,2 +1,2 @@
 ---
-{{ k3s_registries | to_nice_yaml }}
+{{ k3s_registries | to_nice_yaml(indent=2) }}


### PR DESCRIPTION
Fix the issue of bad indentation in rewrite rules when using registry pull through cache

##  Fix length indentation in registry.yaml

### Summary

Fixes #197

### Issue type

- Bugfix

### Test instructions

Deploy k3s with this values into your inventory:

```yaml
k3s_registries:
  mirrors:
    docker.io:
      endpoint:
        - "http://registry.example.com"
      rewrite:
        "(.*)": "docker-hub/$1"
```

### Acceptance Criteria

Produced file /etc/rancher/k3s/registries.yaml  contains following content:

```yaml

mirrors:
  docker.io:
    endpoint:
    - http://registry.example.com
    rewrite:
      (.*): docker-hub/$1

```