### PR TITLE
Refactor/remove-secret-encryption-experimental

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@
 
 ### Notable changes
 
-  - refactor: remove `secrets-encryption` from `k3s_experimental_config` as it is no longer experimental. Fixes #200.
+  - refactor: add `until: 1.23.15` to `secrets-encryption` from `k3s_experimental_config` as it is no longer experimental. Fixes #200.
   - docs(fix): typo in `CONTRIBUTING.md`
 
 ### Contributors

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,19 @@
 ---
 -->
 
+## 2022-03-11, v3.4.0
+
+### Notable changes
+
+  - refactor: remove `secrets-encryption` from `k3s_experimental_config` as it is no longer experimental. Fixes #200.
+  - docs(fix): typo in `CONTRIBUTING.md`
+
+### Contributors
+
+- [dbrennand](https://github.com/dbrennand)
+
+---
+
 ## 2022-11-15, v3.3.1
 
 ### Notable changes

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@ them requiring you to be able to write code. Below is a list of suggested
 contributions welcomed by the community:
 
   - Submit bug reports in GitHub issues
-  - Comment on bug reports with futher information or suggestions
+  - Comment on bug reports with further information or suggestions
   - Suggest new features
   - Create Pull Requests fixing bugs or adding new features
   - Update and improve documentation

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -170,6 +170,8 @@ k3s_experimental_config:
   - setting: selinux
     until: 1.19.4
   - setting: rootless
+  - setting: secrets-encryption
+    until: 1.23.15
   - setting: agent-token
   - setting: agent-token-file
   - setting: cluster-reset

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -170,7 +170,6 @@ k3s_experimental_config:
   - setting: selinux
     until: 1.19.4
   - setting: rootless
-  - setting: secrets-encryption
   - setting: agent-token
   - setting: agent-token-file
   - setting: cluster-reset


### PR DESCRIPTION
## Remove secret-encryption as experimental

### Summary

Fixes #200. The `secret-encryption` is no longer an experimental feature.

<!-- Describe the change below, including rationale and design decisions -->

<!-- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

### Issue type

- Feature

### Additional Information

Please let me know if there is anything else I need to change. I'm not sure whether the `k3s_use_experimental` variable in `molecule/highavailabilityetcd/converge.yml` needs removing because of this change.