### PR TITLE
Fix(tests): Resolve Ansible Lint warnings and fix Molecule tests on GitHub Actions

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -2,3 +2,4 @@
 
 skip_list:
   - role-name
+  - name[template]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,29 @@ defaults:
     working-directory: "xanmanning.k3s"
 
 jobs:
+  ansible-lint:
+    name: Ansible Lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout codebase
+        uses: actions/checkout@v2
+        with:
+          path: "xanmanning.k3s"
+
+      - name: Set up Python 3
+        uses: actions/setup-python@v2
+        with:
+          python-version: "3.x"
+
+      - name: Install test dependencies
+        run: pip3 install -r molecule/lint-requirements.txt
+
+      - name: Run yamllint
+        run: yamllint -s .
+
+      - name: Run ansible-lint
+        run: ansible-lint --exclude molecule/ --exclude meta/
+
   molecule:
     name: Molecule
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
 
   molecule:
     name: Molecule
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
       matrix:

--- a/molecule/autodeploy/molecule.yml
+++ b/molecule/autodeploy/molecule.yml
@@ -7,7 +7,6 @@ driver:
 scenario:
   test_sequence:
     - dependency
-    - lint
     - cleanup
     - destroy
     - syntax
@@ -20,10 +19,6 @@ scenario:
     - verify
     - cleanup
     - destroy
-lint: |
-  set -e
-  yamllint -s .
-  ansible-lint --exclude molecule/ --exclude meta/
 platforms:
   - name: node1
     image: ${MOLECULE_DISTRO:-"geerlingguy/docker-rockylinux8-ansible:latest"}

--- a/molecule/debug/molecule.yml
+++ b/molecule/debug/molecule.yml
@@ -7,7 +7,6 @@ driver:
 scenario:
   test_sequence:
     - dependency
-    - lint
     - cleanup
     - destroy
     - syntax
@@ -20,10 +19,6 @@ scenario:
     - verify
     - cleanup
     - destroy
-lint: |
-  set -e
-  yamllint -s .
-  ansible-lint --exclude molecule/ --exclude meta/
 platforms:
   - name: node1
     image: ${MOLECULE_DISTRO:-"geerlingguy/docker-rockylinux8-ansible:latest"}

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -7,7 +7,6 @@ driver:
 scenario:
   test_sequence:
     - dependency
-    - lint
     - cleanup
     - destroy
     - syntax
@@ -20,10 +19,6 @@ scenario:
     - verify
     - cleanup
     - destroy
-lint: |
-  set -e
-  yamllint -s .
-  ansible-lint --exclude molecule/ --exclude meta/
 platforms:
   - name: node1
     image: ${MOLECULE_DISTRO:-"geerlingguy/docker-rockylinux8-ansible:latest"}

--- a/molecule/highavailabilitydb/molecule.yml
+++ b/molecule/highavailabilitydb/molecule.yml
@@ -7,7 +7,6 @@ driver:
 scenario:
   test_sequence:
     - dependency
-    - lint
     - cleanup
     - destroy
     - syntax
@@ -20,10 +19,6 @@ scenario:
     - verify
     - cleanup
     - destroy
-lint: |
-  set -e
-  yamllint -s .
-  ansible-lint --exclude molecule/ --exclude meta/
 platforms:
   - name: node1
     image: ${MOLECULE_DISTRO:-"geerlingguy/docker-rockylinux8-ansible:latest"}

--- a/molecule/highavailabilityetcd/molecule.yml
+++ b/molecule/highavailabilityetcd/molecule.yml
@@ -7,7 +7,6 @@ driver:
 scenario:
   test_sequence:
     - dependency
-    - lint
     - cleanup
     - destroy
     - syntax
@@ -20,10 +19,6 @@ scenario:
     - verify
     - cleanup
     - destroy
-lint: |
-  set -e
-  yamllint -s .
-  ansible-lint --exclude molecule/ --exclude meta/
 platforms:
   - name: node1
     image: ${MOLECULE_DISTRO:-"geerlingguy/docker-rockylinux8-ansible:latest"}

--- a/molecule/lint-requirements.txt
+++ b/molecule/lint-requirements.txt
@@ -1,0 +1,4 @@
+-r ../requirements.txt
+
+yamllint>=1.25.0
+ansible-lint>=4.3.5

--- a/molecule/nodeploy/molecule.yml
+++ b/molecule/nodeploy/molecule.yml
@@ -7,7 +7,6 @@ driver:
 scenario:
   test_sequence:
     - dependency
-    - lint
     - cleanup
     - destroy
     - syntax
@@ -20,10 +19,6 @@ scenario:
     - verify
     - cleanup
     - destroy
-lint: |
-  set -e
-  yamllint -s .
-  ansible-lint --exclude molecule/ --exclude meta/
 platforms:
   - name: node1
     image: ${MOLECULE_DISTRO:-"geerlingguy/docker-rockylinux8-ansible:latest"}

--- a/molecule/requirements.txt
+++ b/molecule/requirements.txt
@@ -1,6 +1,6 @@
 -r ../requirements.txt
 
-molecule[docker]>=3.2
+molecule-plugins[docker]
 docker>=4.3.1
 yamllint>=1.25.0
 ansible-lint>=4.3.5

--- a/molecule/requirements.txt
+++ b/molecule/requirements.txt
@@ -2,5 +2,3 @@
 
 molecule-plugins[docker]
 docker>=4.3.1
-yamllint>=1.25.0
-ansible-lint>=4.3.5

--- a/tasks/ensure_cluster.yml
+++ b/tasks/ensure_cluster.yml
@@ -87,12 +87,13 @@
   become: "{{ k3s_become }}"
 
 - name: Ensure secondary controllers are started
-  include_tasks: ensure_control_plane_started_{{ ansible_service_mgr }}.yml
+  ansible.builtin.include_tasks: ensure_control_plane_started_{{ ansible_service_mgr }}.yml
   when:
     - k3s_control_node
     - not k3s_primary_control_node
 
-- import_tasks: post_checks_control_plane.yml
+- name: Ensure control plane post checks
+  ansible.builtin.import_tasks: post_checks_control_plane.yml
   when:
     - not k3s_skip_validation
     - not k3s_skip_post_checks
@@ -100,7 +101,8 @@
 - name: Flush Handlers
   ansible.builtin.meta: flush_handlers
 
-- import_tasks: post_checks_nodes.yml
+- name: Ensure node post checks
+  ansible.builtin.import_tasks: post_checks_nodes.yml
   when:
     - not k3s_skip_validation
     - not k3s_skip_post_checks

--- a/tasks/ensure_cluster.yml
+++ b/tasks/ensure_cluster.yml
@@ -92,7 +92,7 @@
     - k3s_control_node
     - not k3s_primary_control_node
 
-- name: Ensure control plane post checks
+- name: Run control plane post checks
   ansible.builtin.import_tasks: post_checks_control_plane.yml
   when:
     - not k3s_skip_validation
@@ -101,7 +101,7 @@
 - name: Flush Handlers
   ansible.builtin.meta: flush_handlers
 
-- name: Ensure node post checks
+- name: Run node post checks
   ansible.builtin.import_tasks: post_checks_nodes.yml
   when:
     - not k3s_skip_validation

--- a/tasks/ensure_drain_and_remove_nodes.yml
+++ b/tasks/ensure_drain_and_remove_nodes.yml
@@ -7,8 +7,12 @@
   become: "{{ k3s_become }}"
 
 - name: Clean up nodes that are in an uninstalled state
+  when:
+    - k3s_check_kubectl.stat.exists is defined
+    - k3s_check_kubectl.stat.exists
+    - k3s_control_delegate is defined
+    - not ansible_check_mode
   block:
-
     - name: Gather a list of nodes
       ansible.builtin.command:
         cmd: "{{ k3s_install_dir }}/kubectl get nodes"
@@ -48,9 +52,3 @@
         - hostvars[item].k3s_state == 'uninstalled'
       loop: "{{ ansible_play_hosts }}"
       become: "{{ k3s_become }}"
-
-  when:
-    - k3s_check_kubectl.stat.exists is defined
-    - k3s_check_kubectl.stat.exists
-    - k3s_control_delegate is defined
-    - not ansible_check_mode

--- a/tasks/ensure_drain_and_remove_nodes.yml
+++ b/tasks/ensure_drain_and_remove_nodes.yml
@@ -23,7 +23,7 @@
       register: kubectl_get_nodes_result
       become: "{{ k3s_become }}"
 
-    - name: Ensure uninstalled nodes are drained
+    - name: Ensure uninstalled nodes are drained # noqa no-changed-when
       ansible.builtin.command:
         cmd: >-
           {{ k3s_install_dir }}/kubectl drain {{ item }}
@@ -40,7 +40,7 @@
       loop: "{{ ansible_play_hosts }}"
       become: "{{ k3s_become }}"
 
-    - name: Ensure uninstalled nodes are removed
+    - name: Ensure uninstalled nodes are removed # noqa no-changed-when
       ansible.builtin.command:
         cmd: "{{ k3s_install_dir }}/kubectl delete node {{ item }}"
       delegate_to: "{{ k3s_control_delegate }}"

--- a/tasks/ensure_installed.yml
+++ b/tasks/ensure_installed.yml
@@ -25,7 +25,7 @@
     path: "{{ k3s_token_location }}"
   register: k3s_token_cluster_check
 
-- name: Ensure control plane started
+- name: Ensure control plane started with {{ ansible_service_mgr }}
   ansible.builtin.include_tasks: ensure_control_plane_started_{{ ansible_service_mgr }}.yml
   when: (k3s_control_node and k3s_controller_list | length == 1)
         or (k3s_primary_control_node and k3s_controller_list | length > 1)

--- a/tasks/ensure_installed.yml
+++ b/tasks/ensure_installed.yml
@@ -16,7 +16,7 @@
 - name: Flush Handlers
   ansible.builtin.meta: flush_handlers
 
-- name: Ensure installed node - Build cluster
+- name: Ensure installed node | Build cluster
   ansible.builtin.include_tasks: ensure_installed_node.yml
   when: k3s_build_cluster
 

--- a/tasks/ensure_installed.yml
+++ b/tasks/ensure_installed.yml
@@ -1,6 +1,6 @@
 ---
 
-- name: Ensure directories
+- name: Ensure directories exist
   ansible.builtin.include_tasks: ensure_directories.yml
   loop: "{{ k3s_ensure_directories_exist }}"
   loop_control:
@@ -16,7 +16,7 @@
 - name: Flush Handlers
   ansible.builtin.meta: flush_handlers
 
-- name: Ensure installed node
+- name: Ensure installed node - Build cluster
   ansible.builtin.include_tasks: ensure_installed_node.yml
   when: k3s_build_cluster
 

--- a/tasks/ensure_installed.yml
+++ b/tasks/ensure_installed.yml
@@ -1,11 +1,13 @@
 ---
 
-- include_tasks: ensure_directories.yml
+- name: Ensure directories
+  ansible.builtin.include_tasks: ensure_directories.yml
   loop: "{{ k3s_ensure_directories_exist }}"
   loop_control:
     loop_var: directory
 
-- include_tasks: ensure_installed_node.yml
+- name: Ensure installed node
+  ansible.builtin.include_tasks: ensure_installed_node.yml
   when:
     - ((k3s_control_node and k3s_controller_list | length == 1)
         or (k3s_primary_control_node and k3s_controller_list | length > 1))
@@ -14,7 +16,8 @@
 - name: Flush Handlers
   ansible.builtin.meta: flush_handlers
 
-- include_tasks: ensure_installed_node.yml
+- name: Ensure installed node
+  ansible.builtin.include_tasks: ensure_installed_node.yml
   when: k3s_build_cluster
 
 - name: Determine if the systems are already clustered
@@ -22,7 +25,8 @@
     path: "{{ k3s_token_location }}"
   register: k3s_token_cluster_check
 
-- include_tasks: ensure_control_plane_started_{{ ansible_service_mgr }}.yml
+- name: Ensure control plane started
+  ansible.builtin.include_tasks: ensure_control_plane_started_{{ ansible_service_mgr }}.yml
   when: (k3s_control_node and k3s_controller_list | length == 1)
         or (k3s_primary_control_node and k3s_controller_list | length > 1)
         or k3s_token_cluster_check.stat.exists

--- a/tasks/ensure_installed.yml
+++ b/tasks/ensure_installed.yml
@@ -16,7 +16,7 @@
 - name: Flush Handlers
   ansible.builtin.meta: flush_handlers
 
-- name: Ensure installed node | Build cluster
+- name: Ensure installed node | k3s_build_cluster
   ansible.builtin.include_tasks: ensure_installed_node.yml
   when: k3s_build_cluster
 

--- a/tasks/ensure_installed_node.yml
+++ b/tasks/ensure_installed_node.yml
@@ -28,6 +28,7 @@
   become: "{{ k3s_become }}"
 
 - name: Ensure cluster token is present when pre-defined
+  when: k3s_control_token is defined
   block:
     - name: Ensure the cluster token file location exists
       ansible.builtin.file:
@@ -44,7 +45,6 @@
       become: "{{ k3s_become }}"
       notify:
         - "Restart k3s {{ k3s_service_handler[ansible_service_mgr] }}"
-  when: k3s_control_token is defined
 
 - name: Ensure k3s service unit file is present
   ansible.builtin.template:

--- a/tasks/ensure_pre_configuration.yml
+++ b/tasks/ensure_pre_configuration.yml
@@ -37,8 +37,11 @@
   loop: "{{ ansible_play_hosts }}"
 
 - name: Ensure a k3s control node is defined if none are found in ansible_play_hosts
+  when:
+    - k3s_controller_list | length < 1
+    - k3s_build_cluster is defined
+    - k3s_build_cluster
   block:
-
     - name: Set the control host
       ansible.builtin.set_fact:
         k3s_control_node: true
@@ -51,11 +54,6 @@
         - hostvars[item].k3s_control_node is defined
         - hostvars[item].k3s_control_node
       loop: "{{ ansible_play_hosts }}"
-
-  when:
-    - k3s_controller_list | length < 1
-    - k3s_build_cluster is defined
-    - k3s_build_cluster
 
 - name: Ensure a primary k3s control node is defined if multiple are found in ansible_play_hosts
   ansible.builtin.set_fact:
@@ -88,6 +86,8 @@
   when: k3s_control_node is defined
 
 - name: Delegate an initializing control plane node
+  when: k3s_registration_address is not defined
+        or k3s_control_delegate is not defined
   block:
     - name: Lookup control node from file
       ansible.builtin.command:
@@ -124,6 +124,3 @@
       when:
         - k3s_registration_address is not defined
         - k3s_control_node_address is not defined
-
-  when: k3s_registration_address is not defined
-        or k3s_control_delegate is not defined

--- a/tasks/ensure_stopped.yml
+++ b/tasks/ensure_stopped.yml
@@ -8,7 +8,7 @@
   when: k3s_non_root is not defined or not k3s_non_root
   become: "{{ k3s_become }}"
 
-- name: Ensure k3s service is started
+- name: Ensure k3s service is stopped
   ansible.builtin.systemd:
     name: k3s
     state: stopped

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,5 +3,5 @@
 - name: Run pre-checks
   ansible.builtin.import_tasks: pre_checks.yml
 
-- name: "Ensure state {{ (k3s_state | lower) | default('installed') }}"
+- name: Ensure state {{ (k3s_state | lower) | default('installed') }}
   ansible.builtin.include_tasks: state_{{ (k3s_state | lower) | default('installed') }}.yml

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 
-- name: Begin pre-checks
+- name: Run pre-checks
   ansible.builtin.import_tasks: pre_checks.yml
 
 - name: "Ensure state {{ (k3s_state | lower) | default('installed') }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,5 +1,7 @@
 ---
 
-- import_tasks: pre_checks.yml
+- name: Begin pre-checks
+  ansible.builtin.import_tasks: pre_checks.yml
 
-- include_tasks: state_{{ (k3s_state | lower) | default('installed') }}.yml
+- name: "Ensure state {{ (k3s_state | lower) | default('installed') }}"
+  ansible.builtin.include_tasks: state_{{ (k3s_state | lower) | default('installed') }}.yml

--- a/tasks/pre_checks.yml
+++ b/tasks/pre_checks.yml
@@ -71,7 +71,7 @@
     - not k3s_skip_validation
     - not k3s_skip_env_checks
 
-- name: Ensure version pre-checks
+- name: Run version pre-checks
   ansible.builtin.include_tasks: pre_checks_version.yml
   when:
     - (k3s_release_version is not defined
@@ -79,7 +79,7 @@
         or k3s_release_version is not regex('\\+k3s[1-9]$'))
     - not k3s_airgap
 
-- name: Ensure cgroups pre-checks
+- name: Run cgroups pre-checks
   ansible.builtin.include_tasks: pre_checks_cgroups.yml
   loop: "{{ k3s_cgroup_subsys }}"
   loop_control:
@@ -88,7 +88,7 @@
     - not k3s_skip_validation
     - not k3s_skip_env_checks
 
-- name: Ensure packages pre-checks
+- name: Run packages pre-checks
   ansible.builtin.include_tasks: pre_checks_packages.yml
   loop: "{{ k3s_check_packages[k3s_os_distribution_version] }}"
   loop_control:
@@ -98,13 +98,13 @@
     - not k3s_skip_env_checks
     - k3s_check_packages[k3s_os_distribution_version] is defined
 
-- name: Ensure issue data pre-checks
+- name: Run issue data pre-checks
   ansible.builtin.include_tasks: pre_checks_issue_data.yml
   when:
     - pyratlabs_issue_controller_dump is defined
     - pyratlabs_issue_controller_dump
 
-- name: Ensure variables pre-checks
+- name: Run variables pre-checks
   ansible.builtin.import_tasks: pre_checks_variables.yml
   when:
     - not k3s_skip_validation
@@ -114,17 +114,17 @@
   when:
     - not k3s_skip_validation
 
-- name: Ensure unsupported rootless pre-checks
+- name: Run unsupported rootless pre-checks
   ansible.builtin.import_tasks: pre_checks_unsupported_rootless.yml
   when:
     - k3s_runtime_config.rootless is defined
     - k3s_runtime_config.rootless
     - not k3s_skip_validation
 
-- name: Ensure preconfiguration
+- name: Run preconfiguration tasks
   ansible.builtin.import_tasks: ensure_pre_configuration.yml
 
-- name: Ensure control node count pre-checks
+- name: Run control node count pre-checks
   ansible.builtin.import_tasks: pre_checks_control_node_count.yml
   when:
     - k3s_build_cluster is defined

--- a/tasks/pre_checks.yml
+++ b/tasks/pre_checks.yml
@@ -50,7 +50,7 @@
     - not k3s_skip_validation
     - not k3s_skip_env_checks
 
-- name: Determing if {{ ansible_service_mgr }} is actually openrc
+- name: Determining if {{ ansible_service_mgr }} is actually openrc
   ansible.builtin.stat:
     path: /sbin/openrc-run
   register: k3s_check_openrc_run
@@ -71,14 +71,16 @@
     - not k3s_skip_validation
     - not k3s_skip_env_checks
 
-- include_tasks: pre_checks_version.yml
+- name: Ensure version pre-checks
+  ansible.builtin.include_tasks: pre_checks_version.yml
   when:
     - (k3s_release_version is not defined
         or not k3s_release_version
         or k3s_release_version is not regex('\\+k3s[1-9]$'))
     - not k3s_airgap
 
-- include_tasks: pre_checks_cgroups.yml
+- name: Ensure cgroups pre-checks
+  ansible.builtin.include_tasks: pre_checks_cgroups.yml
   loop: "{{ k3s_cgroup_subsys }}"
   loop_control:
     loop_var: cgroup
@@ -86,7 +88,8 @@
     - not k3s_skip_validation
     - not k3s_skip_env_checks
 
-- include_tasks: pre_checks_packages.yml
+- name: Ensure packages pre-checks
+  ansible.builtin.include_tasks: pre_checks_packages.yml
   loop: "{{ k3s_check_packages[k3s_os_distribution_version] }}"
   loop_control:
     loop_var: package
@@ -95,28 +98,34 @@
     - not k3s_skip_env_checks
     - k3s_check_packages[k3s_os_distribution_version] is defined
 
-- include_tasks: pre_checks_issue_data.yml
+- name: Ensure issue data pre-checks
+  ansible.builtin.include_tasks: pre_checks_issue_data.yml
   when:
     - pyratlabs_issue_controller_dump is defined
     - pyratlabs_issue_controller_dump
 
-- import_tasks: pre_checks_variables.yml
+- name: Ensure variables pre-checks
+  ansible.builtin.import_tasks: pre_checks_variables.yml
   when:
     - not k3s_skip_validation
 
-- import_tasks: pre_checks_experimental_variables.yml
+- name: Ensure experimental variables pre-checks
+  ansible.builtin.import_tasks: pre_checks_experimental_variables.yml
   when:
     - not k3s_skip_validation
 
-- import_tasks: pre_checks_unsupported_rootless.yml
+- name: Ensure unsupported rootless pre-checks
+  ansible.builtin.import_tasks: pre_checks_unsupported_rootless.yml
   when:
     - k3s_runtime_config.rootless is defined
     - k3s_runtime_config.rootless
     - not k3s_skip_validation
 
-- import_tasks: ensure_pre_configuration.yml
+- name: Ensure preconfiguration
+  ansible.builtin.import_tasks: ensure_pre_configuration.yml
 
-- import_tasks: pre_checks_control_node_count.yml
+- name: Ensure control node count pre-checks
+  ansible.builtin.import_tasks: pre_checks_control_node_count.yml
   when:
     - k3s_build_cluster is defined
     - k3s_build_cluster

--- a/tasks/pre_checks.yml
+++ b/tasks/pre_checks.yml
@@ -121,7 +121,7 @@
     - k3s_runtime_config.rootless
     - not k3s_skip_validation
 
-- name: Run preconfiguration tasks
+- name: Run pre-configuration tasks
   ansible.builtin.import_tasks: ensure_pre_configuration.yml
 
 - name: Run control node count pre-checks

--- a/tasks/state_downloaded.yml
+++ b/tasks/state_downloaded.yml
@@ -1,15 +1,15 @@
 ---
 
-- name: Ensure version pre-checks
+- name: Run version pre-checks
   ansible.builtin.import_tasks: pre_checks_version.yml
   when:
     - k3s_release_version is not defined or not k3s_release_version
     - not k3s_airgap
 
-- name: Ensure downloads
+- name: Run k3s binary download and install tasks
   ansible.builtin.import_tasks: ensure_downloads.yml
   when: not k3s_airgap
 
-- name: Ensure uploads
+- name: Run k3s binary upload tasks | k3s_airgap
   ansible.builtin.import_tasks: ensure_uploads.yml
   when: k3s_airgap

--- a/tasks/state_downloaded.yml
+++ b/tasks/state_downloaded.yml
@@ -1,12 +1,15 @@
 ---
 
-- import_tasks: pre_checks_version.yml
+- name: Ensure version pre-checks
+  ansible.builtin.import_tasks: pre_checks_version.yml
   when:
     - k3s_release_version is not defined or not k3s_release_version
     - not k3s_airgap
 
-- import_tasks: ensure_downloads.yml
+- name: Ensure downloads
+  ansible.builtin.import_tasks: ensure_downloads.yml
   when: not k3s_airgap
 
-- import_tasks: ensure_uploads.yml
+- name: Ensure uploads
+  ansible.builtin.import_tasks: ensure_uploads.yml
   when: k3s_airgap

--- a/tasks/state_installed.yml
+++ b/tasks/state_installed.yml
@@ -1,25 +1,32 @@
 ---
 
-- import_tasks: ensure_drain_and_remove_nodes.yml
+- name: Ensure nodes are drained and removed
+  ansible.builtin.import_tasks: ensure_drain_and_remove_nodes.yml
 
-- import_tasks: determine_systemd_context.yml
+- name: Determine systemd context
+  ansible.builtin.import_tasks: determine_systemd_context.yml
 
 - name: Flush Handlers
   ansible.builtin.meta: flush_handlers
 
-- import_tasks: ensure_downloads.yml
+- name: Run k3s binary download and install tasks
+  ansible.builtin.import_tasks: ensure_downloads.yml
   when: not k3s_airgap
 
-- import_tasks: ensure_uploads.yml
+- name: Run k3s binary upload tasks | k3s_airgap
+  ansible.builtin.import_tasks: ensure_uploads.yml
   when: k3s_airgap
 
-- import_tasks: ensure_k3s_auto_deploy.yml
+- name: Run auto-deploy manifests and pod manifests tasks
+  ansible.builtin.import_tasks: ensure_k3s_auto_deploy.yml
   when:
     - k3s_primary_control_node
 
-- import_tasks: ensure_k3s_config_files.yml
+- name: Ensure k3s configuration files are copied to controllers and agents
+  ansible.builtin.import_tasks: ensure_k3s_config_files.yml
 
-- import_tasks: ensure_installed.yml
+- name: Run k3s installation tasks
+  ansible.builtin.import_tasks: ensure_installed.yml
 
 - name: Ensure containerd registries
   ansible.builtin.include_tasks: ensure_containerd_registries.yml
@@ -27,13 +34,14 @@
     - k3s_registries is defined
     - ('rootless' not in k3s_runtime_config or not k3s_runtime_config.rootless)
 
-- name: Ensure cluster pre-checks
+- name: Run cluster pre-checks
   ansible.builtin.include_tasks: pre_checks_cluster.yml
   when:
     - k3s_control_delegate is defined
     - k3s_control_delegate == inventory_hostname
 
-- import_tasks: ensure_cluster.yml
+- name: Run k3s cluster tasks
+  ansible.builtin.import_tasks: ensure_cluster.yml
   when:
     - k3s_build_cluster is defined
     - k3s_build_cluster

--- a/tasks/state_installed.yml
+++ b/tasks/state_installed.yml
@@ -21,12 +21,14 @@
 
 - import_tasks: ensure_installed.yml
 
-- include_tasks: ensure_containerd_registries.yml
+- name: Ensure containerd registries
+  ansible.builtin.include_tasks: ensure_containerd_registries.yml
   when:
     - k3s_registries is defined
     - ('rootless' not in k3s_runtime_config or not k3s_runtime_config.rootless)
 
-- include_tasks: pre_checks_cluster.yml
+- name: Ensure cluster pre-checks
+  ansible.builtin.include_tasks: pre_checks_cluster.yml
   when:
     - k3s_control_delegate is defined
     - k3s_control_delegate == inventory_hostname

--- a/tasks/state_restarted.yml
+++ b/tasks/state_restarted.yml
@@ -1,5 +1,7 @@
 ---
 
-- import_tasks: ensure_stopped.yml
+- name: Ensure k3s is stopped
+  ansible.builtin.import_tasks: ensure_stopped.yml
 
-- import_tasks: ensure_started.yml
+- name: Ensure k3s is started
+  ansible.builtin.import_tasks: ensure_started.yml

--- a/tasks/state_started.yml
+++ b/tasks/state_started.yml
@@ -1,3 +1,4 @@
 ---
 
-- import_tasks: ensure_started.yml
+- name: Ensure k3s is started
+  ansible.builtin.import_tasks: ensure_started.yml

--- a/tasks/state_stopped.yml
+++ b/tasks/state_stopped.yml
@@ -1,3 +1,4 @@
 ---
 
-- import_tasks: ensure_stopped.yml
+- name: Ensure k3s is stopped
+  ansible.builtin.import_tasks: ensure_stopped.yml

--- a/tasks/state_uninstalled.yml
+++ b/tasks/state_uninstalled.yml
@@ -1,12 +1,16 @@
 ---
 
-- import_tasks: ensure_pre_configuration.yml
+- name: Run pre-configuration tasks
+  ansible.builtin.import_tasks: ensure_pre_configuration.yml
 
-- import_tasks: ensure_drain_and_remove_nodes.yml
+- name: Ensure nodes are drained and removed
+  ansible.builtin.import_tasks: ensure_drain_and_remove_nodes.yml
 
-- import_tasks: ensure_uninstalled.yml
+- name: Run uninstall tasks
+  ansible.builtin.import_tasks: ensure_uninstalled.yml
 
-- import_tasks: post_checks_uninstalled.yml
+- name: Run uninstall post checks
+  ansible.builtin.import_tasks: post_checks_uninstalled.yml
   when:
     - not k3s_skip_validation
     - not k3s_skip_post_checks

--- a/tasks/state_validated.yml
+++ b/tasks/state_validated.yml
@@ -1,5 +1,7 @@
 ---
 
-- import_tasks: post_checks_control_plane.yml
+- name: Run control plane post checks
+  ansible.builtin.import_tasks: post_checks_control_plane.yml
 
-- import_tasks: post_checks_nodes.yml
+- name: Run node post checks
+  ansible.builtin.import_tasks: post_checks_nodes.yml


### PR DESCRIPTION
## TITLE

### Summary

Fix Ansible Lint warnings and resolve Molecule tests failing.

Molecule v5.0.0 dropped support for `lint`, see https://github.com/ansible-community/molecule/pull/3802 so I created a separate CI job for running `yamllint` and `ansible-lint`.

To fix the molecule tests, I've removed the `lint` section and `lint` test scenario from each `molecule.yml` file. Furthermore, the Molecule tests were failing, and I suspect this was because `ubuntu-latest` was updated to [Ubuntu 22.04 sometime ago](https://github.blog/changelog/2022-11-09-github-actions-ubuntu-latest-workflows-will-use-ubuntu-22-04/#:~:text=Ubuntu%2022.04%20became%20generally%20available,beginning%20on%20October%201%2C%202022) and cgroups v2 was causing all tests to fail. I saw similar issues in https://github.com/dbrennand/ansible-role-caddy-docker/pull/6/commits/2d23b794fa111c3a018a077a78a4f1d3c652a9ae and I resolved by dropping to `ubuntu-20.04` to get the tests in a working state again.

<!-- Describe the change below, including rationale and design decisions -->

<!-- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

### Issue type

<!-- Pick one below and delete the rest -->
- Bugfix

### Test instructions

N/A
<!-- Please provide instructions for testing this PR -->

### Acceptance Criteria

- [x] GitHub Actions Molecule tests pass (WIP).

<!-- Please list criteria required to ensure this change has been sufficiently reviewed.  -->

<!-- Example ticklist:
  - [ ] GitHub Actions Build passes.
  - [ ] Documentation updated.
-->

### Additional Information

<!-- Include additional information to help people understand the change here -->

<!-- Paste verbatim command output below, e.g. before and after your change -->

```text

```
