### PR TITLE
Create registries.yaml if k3s_registries.mirrors or k3s_registries.configs are not None

### DIFF
--- a/tasks/state_installed.yml
+++ b/tasks/state_installed.yml
@@ -31,7 +31,7 @@
 - name: Ensure containerd registries
   ansible.builtin.include_tasks: ensure_containerd_registries.yml
   when:
-    - k3s_registries is defined
+    - (k3s_registries.mirrors | default(None)) != None or (k3s_registries.configs | default(None) != None)
     - ('rootless' not in k3s_runtime_config or not k3s_runtime_config.rootless)
 
 - name: Run cluster pre-checks


### PR DESCRIPTION
## Create registries.yaml if k3s_registries.mirrors or k3s_registries.configs are not None

### Summary

The task `Ensure containerd registries` is run when `k3s_registries is defined`, but `k3s_registries` is always defined in  [defaults](https://github.com/PyratLabs/ansible-role-k3s/blob/de1bd094e55b4c7b796bafc83fc55e6cb157b14f/defaults/main.yml#L138). This then creates a yaml file with null values for configs and mirrors :
```
root@deb11:~# cat /etc/rancher/k3s/registries.yaml 
---
configs: null
mirrors: null
```
It can be problematic if there is already a `registries.yaml` file present and it's overwritten by the role.

This MR adds a two conditions when importing the task. The task is imported only if `k3s_registries.mirrors` or `k3s_registries.configs` are not None. Both values are set to None by default.

<!-- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #205

### Issue type

<!-- Pick one below and delete the rest -->
- Bugfix


### Test instructions

If `registries` variable is not set (in the inventory or in a playbook) then the task `Ensure containerd registries file exists` is skipped and `{{ k3s_config_dir }}/registries.yaml` is not created.

### Acceptance Criteria

<!-- Please list criteria required to ensure this change has been sufficiently reviewed.  -->

<!-- Example ticklist:
  - [ ] GitHub Actions Build passes.
  - [ ] Documentation updated.
-->

### Additional Information

<!-- Include additional information to help people understand the change here -->

<!-- Paste verbatim command output below, e.g. before and after your change -->

```text

```
