### PR TITLE
Compare `kubectl get nodes` with ansible_hostname, not ansible_fqdn/i…

### DIFF
--- a/tasks/ensure_drain_and_remove_nodes.yml
+++ b/tasks/ensure_drain_and_remove_nodes.yml
@@ -34,7 +34,7 @@
       run_once: true
       when:
         - kubectl_get_nodes_result.stdout is defined
-        - item in kubectl_get_nodes_result.stdout
+        - hostvars[item].ansible_hostname in kubectl_get_nodes_result.stdout
         - hostvars[item].k3s_state is defined
         - hostvars[item].k3s_state == 'uninstalled'
       loop: "{{ ansible_play_hosts }}"
@@ -47,7 +47,7 @@
       run_once: true
       when:
         - kubectl_get_nodes_result.stdout is defined
-        - item in kubectl_get_nodes_result.stdout
+        - hostvars[item].ansible_hostname in kubectl_get_nodes_result.stdout
         - hostvars[item].k3s_state is defined
         - hostvars[item].k3s_state == 'uninstalled'
       loop: "{{ ansible_play_hosts }}"


### PR DESCRIPTION
Compare `kubectl get nodes` with ansible_hostname, not ansible_fqdn/i…

## TITLE

### Summary

Node drain and delete task should compare `kubectl get nodes` output with host hostname not fqdn. 
ansible_play_hosts contains inventory hostname which is often FQDN. 

