### PR TITLE
add support for experimental option "prefer-bundled-bin"

### DIFF
--- a/vars/main.yml
+++ b/vars/main.yml
@@ -176,6 +176,7 @@ k3s_experimental_config:
   - setting: agent-token-file
   - setting: cluster-reset
     until: 1.19.5
+  - setting: prefer-bundled-bin
 
 # Config items that should be marked as deprecated
 k3s_deprecated_config:


### PR DESCRIPTION
## Add support for experimental option "prefer-bundled-bin"

### Summary

This pull request adds support for the experimental option `prefer-bundled-bin`  to use bundled iptables instead of the OS iptables (which can be buggy see: https://docs.k3s.io/advanced#old-iptables-versions)

It wil be then added to the k3s config :

```text
---

cluster-init: true
default-local-storage-path: /opt/storage
disable-network-policy: true
flannel-backend: none
node-label:
- group=vm
prefer-bundled-bin: true <--- this one
```

Closes #213 

