### PR TITLE
kubectl commands on node must use short name

### DIFF
--- a/tasks/ensure_drain_and_remove_nodes.yml
+++ b/tasks/ensure_drain_and_remove_nodes.yml
@@ -26,7 +26,7 @@
     - name: Ensure uninstalled nodes are drained # noqa no-changed-when
       ansible.builtin.command:
         cmd: >-
-          {{ k3s_install_dir }}/kubectl drain {{ item }}
+          {{ k3s_install_dir }}/kubectl drain {{ hostvars[item].ansible_hostname }}
             --ignore-daemonsets
             --{{ k3s_drain_command[ansible_version.string is version_compare('1.22', '>=')] }}
             --force
@@ -42,7 +42,7 @@
 
     - name: Ensure uninstalled nodes are removed # noqa no-changed-when
       ansible.builtin.command:
-        cmd: "{{ k3s_install_dir }}/kubectl delete node {{ item }}"
+        cmd: "{{ k3s_install_dir }}/kubectl delete node {{ hostvars[item].ansible_hostname }}"
       delegate_to: "{{ k3s_control_delegate }}"
       run_once: true
       when:


### PR DESCRIPTION
## Kubectl commands on node must use short name


### Summary

Fix for 
- `kubectl drain <node_name>`
- `kubectl delete <node_name>`

In addition to https://github.com/PyratLabs/ansible-role-k3s/pull/212

when using just `{{ item }}` a hostname from inventory file is substituted, but kubectl operates on base names.

### Issue type
- Bugfix



