### PR TITLE
Containerd registries config not live

### DIFF
--- a/tasks/state_installed.yml
+++ b/tasks/state_installed.yml
@@ -44,3 +44,6 @@
     - k3s_build_cluster is defined
     - k3s_build_cluster
     - k3s_registration_address is defined
+
+- name: Flush Handlers
+  ansible.builtin.meta: flush_handlers


### PR DESCRIPTION
## Containerd registries config not live

### Summary

I found a bug where my custom containerd registries config wasn't live, despite the correct `notify` handlers being specified in the 'Ensure containerd registries file exists' task.

This change fixes that by ensuring the handlers get triggered.

### Issue type

- Bugfix