### PR TITLE
Install killall,uninstall scripts into k3s_install_dir

### DIFF
--- a/tasks/ensure_installed_node.yml
+++ b/tasks/ensure_installed_node.yml
@@ -85,7 +85,7 @@
 - name: Ensure k3s killall script is present
   ansible.builtin.template:
     src: k3s-killall.sh.j2
-    dest: "/usr/local/bin/k3s-killall.sh"
+    dest: "{{ k3s_install_dir }}/k3s-killall.sh"
     mode: 0700
   become: "{{ k3s_become }}"
   when:
@@ -95,7 +95,7 @@
 - name: Ensure k3s uninstall script is present
   ansible.builtin.template:
     src: k3s-uninstall.sh.j2
-    dest: "/usr/local/bin/k3s-uninstall.sh"
+    dest: "{{ k3s_install_dir }}/k3s-uninstall.sh"
     mode: 0700
   become: "{{ k3s_become }}"
   when:

--- a/tasks/ensure_uninstalled.yml
+++ b/tasks/ensure_uninstalled.yml
@@ -2,17 +2,17 @@
 
 - name: Check to see if k3s-killall.sh exits
   ansible.builtin.stat:
-    path: /usr/local/bin/k3s-killall.sh
+    path: "{{ k3s_install_dir }}/k3s-killall.sh"
   register: check_k3s_killall_script
 
 - name: Check to see if k3s-uninstall.sh exits
   ansible.builtin.stat:
-    path: /usr/local/bin/k3s-uninstall.sh
+    path: "{{ k3s_install_dir }}/k3s-uninstall.sh"
   register: check_k3s_uninstall_script
 
 - name: Run k3s-killall.sh
   ansible.builtin.command:
-    cmd: /usr/local/bin/k3s-killall.sh
+    cmd: "{{ k3s_install_dir }}/k3s-killall.sh"
   register: k3s_killall
   changed_when: k3s_killall.rc == 0
   when: check_k3s_killall_script.stat.exists
@@ -20,9 +20,9 @@
 
 - name: Run k3s-uninstall.sh
   ansible.builtin.command:
-    cmd: /usr/local/bin/k3s-uninstall.sh
+    cmd: "{{ k3s_install_dir }}/k3s-uninstall.sh"
   args:
-    removes: /usr/local/bin/k3s-uninstall.sh
+    removes: "{{ k3s_install_dir }}/k3s-uninstall.sh"
   register: k3s_uninstall
   changed_when: k3s_uninstall.rc == 0
   when: check_k3s_uninstall_script.stat.exists

--- a/tasks/post_checks_uninstalled.yml
+++ b/tasks/post_checks_uninstalled.yml
@@ -22,7 +22,7 @@
 
 - name: Check k3s-killall.sh is removed
   ansible.builtin.stat:
-    path: /usr/local/bin/k3s-killall.sh
+    path: "{{ k3s_install_dir }}/k3s-killall.sh"
   register: check_k3s_killall
 
 - name: Fail if k3s-killall.sh script still exists
@@ -32,7 +32,7 @@
 
 - name: Check k3s-uninstall.sh is removed
   ansible.builtin.stat:
-    path: /usr/local/bin/k3s-uninstall.sh
+    path: "{{ k3s_install_dir }}/k3s-uninstall.sh"
   register: check_k3s_uninstall
 
 - name: Fail if k3s-uninstall.sh script still exists

--- a/templates/k3s-uninstall.sh.j2
+++ b/templates/k3s-uninstall.sh.j2
@@ -2,7 +2,7 @@
 set -x
 [ $(id -u) -eq 0 ] || exec sudo $0 $@
 
-/usr/local/bin/k3s-killall.sh
+{{ k3s_install_dir }}/k3s-killall.sh
 
 if command -v systemctl; then
     systemctl disable k3s
@@ -17,7 +17,7 @@ rm -f {{ k3s_systemd_unit_dir }}/k3s.service
 rm -f {{ k3s_systemd_unit_dir }}/k3s.env
 
 remove_uninstall() {
-    rm -f /usr/local/bin/k3s-uninstall.sh
+    rm -f {{ k3s_install_dir }}/k3s-uninstall.sh
 }
 trap remove_uninstall EXIT
 
@@ -38,7 +38,7 @@ rm -rf /run/flannel
 rm -rf {{ k3s_runtime_config['data-dir'] | default(k3s_data_dir) }}
 rm -rf /var/lib/kubelet
 rm -f {{ k3s_install_dir }}/k3s
-rm -f /usr/local/bin/k3s-killall.sh
+rm -f {{ k3s_install_dir }}/k3s-killall.sh
 
 if type yum >/dev/null 2>&1; then
     yum remove -y k3s-selinux


### PR DESCRIPTION
## Install killall,uninstall scripts into k3s_install_dir

### Summary

Installs killall and uninstall scripts into configured `k3s_install_dir` instead of hard-coded `/usr/local/bin`. This is a feature for TrueNAS scale Dragonfish, where `/usr/` is now mounted readonly.

Closes #223

<!-- Describe the change below, including rationale and design decisions -->

<!-- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

### Issue type

<!-- Pick one below and delete the rest -->
- Feature

### Test instructions

<!-- Please provide instructions for testing this PR -->

### Acceptance Criteria

<!-- Please list criteria required to ensure this change has been sufficiently reviewed.  -->

<!-- Example ticklist:
  - [ ] GitHub Actions Build passes.
  - [ ] Documentation updated.
-->

### Additional Information

<!-- Include additional information to help people understand the change here -->

<!-- Paste verbatim command output below, e.g. before and after your change -->

```text

```
