### PR TITLE
add k3s_service_exec_start_pre_vars for the k3s service

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -107,6 +107,19 @@ k3s_service_env_vars: {}
 # the target as this role will not populate this file.
 k3s_service_env_file: false
 
+# Additional ExecStartPre commands for the k3s service in systemd
+# This dictionary can be used to specify additional ExecStartPre commands
+# for the k3s service. These commands will be executed before the main
+# service starts. For example, the command below removes the
+# cpu_manager_state file if it exists.
+#
+# Usage example:
+# k3s_service_exec_start_pre_vars:
+#   - "-/usr/bin/rm -f /var/lib/kubelet/cpu_manager_state"
+#
+# Note: The "-" prefix before the command ensures that systemd ignores
+# any errors that occur when executing the command.
+k3s_service_exec_start_pre_vars: {}
 
 ##
 # Server Configuration

--- a/templates/k3s.service.j2
+++ b/templates/k3s.service.j2
@@ -29,6 +29,11 @@ EnvironmentFile={{ k3s_service_env_file }}
 ExecStartPre=/bin/sh -xc '! /usr/bin/systemctl is-enabled --quiet nm-cloud-setup.service'
 ExecStartPre=-/sbin/modprobe br_netfilter
 ExecStartPre=-/sbin/modprobe overlay
+{% if k3s_service_exec_start_pre_vars is defined and k3s_service_exec_start_pre_vars is iterable %}
+{% for exec_start_pre_var in k3s_service_exec_start_pre_vars %}
+ExecStartPre={{ exec_start_pre_var }}
+{% endfor %}
+{% endif %}
 {% filter regex_replace('\s+', ' ') %}
 {% filter replace('\n', ' ') %}
 ExecStart={{ k3s_install_dir }}/k3s


### PR DESCRIPTION
Add `k3s_service_exec_start_pre_vars` for the k3s service. This dictionary can be used to specify additional ExecStartPre commands for the k3s service. These commands will be executed before the main service starts. 

For example, the command below removes the cpu_manager_state file if it exists.
```
k3s_service_exec_start_pre_vars:
   - "-/usr/bin/rm -f /var/lib/kubelet/cpu_manager_state"