### PR TITLE
Fix node registration ip on dual stack

### DIFF
--- a/tasks/ensure_pre_configuration.yml
+++ b/tasks/ensure_pre_configuration.yml
@@ -147,7 +147,7 @@
 
     - name: Ensure the node registration address is defined from node-ip
       ansible.builtin.set_fact:
-        k3s_registration_address: "{{ hostvars[k3s_control_delegate].k3s_node_ip }}"
+        k3s_registration_address: "{{ (hostvars[k3s_control_delegate].k3s_node_ip | split(','))[0] | ipwrap }}"
       check_mode: false
       when:
         - k3s_registration_address is not defined


### PR DESCRIPTION
When using a user defined node ip on a dual stack cluster, k3s_node_ip will contain "ipv4,ipv6" IP. In order to properly set the registration IP, the first (preferred) IP in the list is used, and if it is the IPv6 IP it will be URL wrapped.
