### PR TITLE
Check for cgroup v2 controllers

### DIFF
--- a/tasks/pre_checks_cgroups.yml
+++ b/tasks/pre_checks_cgroups.yml
@@ -2,7 +2,7 @@
 
 - name: Check if {{ cgroup.name }} cgroup is enabled
   ansible.builtin.command:
-    cmd: 'grep -E "^{{ cgroup.name }}\s+.*\s+1$" /proc/cgroups'
+    cmd: 'grep -E "{{ cgroup.name }}" /sys/fs/cgroup/cgroup.controllers'
   failed_when: false
   changed_when: false
   check_mode: false


### PR DESCRIPTION
## Update cgroup pre-check task

### Summary

Due to updates in the kernel =>6.12, cpuset does not show up anymore under `/proc/cgroups`. This PR updates the location for the pre-check to check on the cgroup controllers available instead.

<!-- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

### Issue type

<!-- Pick one below and delete the rest -->
- Bugfix

### Test instructions

Ran manual tests under kernel v6.12:

```bash
$ uname -r
6.12.7-200.fc41.x86_64
$ grep -E "memory" /sys/fs/cgroup/cgroup.controllers
cpuset cpu io memory hugetlb pids rdma misc
```

Ran manual tests under kernel v6.11:

```bash
$ uname -r
6.11.11-300.fc41.x86_64
$ grep -E "memory" /sys/fs/cgroup/cgroup.controllers
cpuset cpu io memory hugetlb pids rdma misc
```

Also ran test on Arch Linux kernel 6.12:

```bash
$ uname -r
6.12.9-arch1-1
$ grep -E "memory" /sys/fs/cgroup/cgroup.controllers
cpuset cpu io memory hugetlb pids rdma misc
```

### Additional Information

Fixes #232 