### PR TITLE
fix dummy cluster token for ansible_check_mode

### DIFF
--- a/tasks/ensure_cluster.yml
+++ b/tasks/ensure_cluster.yml
@@ -22,6 +22,7 @@
     k3s_control_token_content: "{{ k3s_control_delegate | to_uuid }}"
   check_mode: false
   when:
+    - k3s_control_token is not defined
     - ansible_check_mode
 
 - name: Ensure the cluster token file location exists


### PR DESCRIPTION
## TITLE

### Summary

In the task file `ensure_cluster` the task `Ensure dummy cluster token is defined for ansible_check_mode` is faulty: 
- when is run against cluster (>=2 nodes) and 
- when playbook with the role is executed in check_mode/dry-run.
- when `k3s_control_token` is already defined

 This task should have an exclusion to not run if `k3s_control_token` is already defined.

### Issue type

- Bugfix

### Test instructions

...

### Acceptance Criteria

...

### Additional Information

- Fix affects only `check_mode` / `dry-run`
