### PR TITLE
ci: fix tests, update workflow deps and tested platforms

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,23 +15,29 @@ defaults:
   run:
     working-directory: "xanmanning.k3s"
 
+env:
+  UV_SYSTEM_PYTHON: "1"
+
 jobs:
   ansible-lint:
     name: Ansible Lint
     runs-on: ubuntu-latest
     steps:
       - name: Checkout codebase
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           path: "xanmanning.k3s"
 
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v6
+
       - name: Set up Python 3
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: "3.x"
 
       - name: Install test dependencies
-        run: pip3 install -r molecule/lint-requirements.txt
+        run: uv pip install -r molecule/lint-requirements.txt
 
       - name: Run yamllint
         run: yamllint -s .
@@ -41,51 +47,51 @@ jobs:
 
   molecule:
     name: Molecule
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:
         include:
+          - distro: geerlingguy/docker-debian12-ansible:latest
+            scenario: nodeploy
+            prebuilt: 'true'
           - distro: geerlingguy/docker-debian11-ansible:latest
+            scenario: default
+            prebuilt: 'true'
+          - distro: geerlingguy/docker-ubuntu2404-ansible:latest
             scenario: default
             prebuilt: 'true'
           - distro: geerlingguy/docker-ubuntu2204-ansible:latest
             scenario: default
             prebuilt: 'true'
-          - distro: geerlingguy/docker-amazonlinux2-ansible:latest
-            scenario: default
-            prebuilt: 'true'
-          - distro: geerlingguy/docker-ubuntu2004-ansible:latest
-            scenario: default
-            prebuilt: 'true'
-          - distro: geerlingguy/docker-fedora35-ansible:latest
-            scenario: nodeploy
-            prebuilt: 'true'
-          - distro: geerlingguy/docker-fedora34-ansible:latest
+          - distro: geerlingguy/docker-fedora42-ansible:latest
             scenario: highavailabilitydb
             prebuilt: 'true'
-          - distro: geerlingguy/docker-fedora33-ansible:latest
+          - distro: geerlingguy/docker-fedora41-ansible:latest
             scenario: autodeploy
-          - distro: xanmanning/docker-alpine-ansible:3.16
-            scenario: highavailabilityetcd
-            prebuilt: 'false'
+          - distro: geerlingguy/docker-rockylinux10-ansible:latest
+            scenario: nodeploy
+            prebuilt: 'true'
           - distro: geerlingguy/docker-rockylinux9-ansible:latest
             scenario: highavailabilityetcd
             prebuilt: 'true'
 
     steps:
       - name: Checkout codebase
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           path: "xanmanning.k3s"
 
-      - name: Set up Python 3
-        uses: actions/setup-python@v2
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
         with:
           python-version: "3.x"
 
       - name: Install test dependencies
-        run: pip3 install -r molecule/requirements.txt
+        run: uv pip install -r molecule/requirements.txt
 
       - name: Run Molecule tests
         run: molecule test --scenario-name "${{ matrix.scenario }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,23 +10,29 @@ defaults:
   run:
     working-directory: "xanmanning.k3s"
 
+env:
+  UV_SYSTEM_PYTHON: "1"
+
 jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
     steps:
       - name: Checkout codebase
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           path: "xanmanning.k3s"
 
-      - name: Set up Python 3
-        uses: actions/setup-python@v2
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
         with:
           python-version: "3.x"
 
       - name: Install Ansible
-        run: pip3 install -r requirements.txt
+        run: uv pip install -r requirements.txt
 
       - name: Trigger a new import on Galaxy
         run: ansible-galaxy role import --api-key ${{ secrets.GALAXY_API_KEY }} $(echo ${{ github.repository }} | cut -d/ -f1) $(echo ${{ github.repository }} | cut -d/ -f2)

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.ansible
 .vagrant
 *.retry
 VAULT_PASSWORD

--- a/.mise.toml
+++ b/.mise.toml
@@ -1,0 +1,8 @@
+[env]
+_.python.venv = { path = "{{config_root}}/.venv", create = true }
+PY_COLORS = '1'
+ANSIBLE_FORCE_COLOR = '1'
+
+[tools]
+"python" = "3.13"
+"uv" = "latest"

--- a/README.md
+++ b/README.md
@@ -30,16 +30,17 @@ You can install dependencies using the requirements.txt file in this repository:
 This role has been tested against the following Linux Distributions:
 
   - Alpine Linux
-  - Amazon Linux 2
   - Archlinux
   - CentOS 8
   - Debian 11
-  - Fedora 31
-  - Fedora 32
-  - Fedora 33
+  - Debian 12
+  - Fedora 41
+  - Fedora 42
   - openSUSE Leap 15
-  - RockyLinux 8
-  - Ubuntu 20.04 LTS
+  - RockyLinux 9
+  - RockyLinux 10
+  - Ubuntu 22.04 LTS
+  - Ubuntu 24.04 LTS
 
 :warning: The v3 releases of this role only supports `k3s >= v1.19`, for
 `k3s < v1.19` please consider updating or use the v1.x releases of this role.

--- a/molecule/autodeploy/converge.yml
+++ b/molecule/autodeploy/converge.yml
@@ -4,7 +4,7 @@
   become: true
   vars:
     molecule_is_test: true
-    k3s_release_version: v1.22
+    k3s_release_version: v1.33
     k3s_build_cluster: false
     k3s_control_token: 55ba04e5-e17d-4535-9170-3e4245453f4d
     k3s_install_dir: /opt/k3s/bin

--- a/molecule/autodeploy/converge.yml
+++ b/molecule/autodeploy/converge.yml
@@ -15,8 +15,9 @@
       disable:
         - metrics-server
         - traefik
-    # k3s_agent:
-    #   snapshotter: native
+      snapshotter: native
+    k3s_agent:
+      snapshotter: native
     k3s_server_manifests_templates:
       - "molecule/autodeploy/templates/00-ns-monitoring.yml.j2"
     k3s_server_manifests_urls:
@@ -25,4 +26,4 @@
     k3s_service_env_vars:
       K3S_TEST_VAR: "Hello world!"
   roles:
-    - role: "{{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY') | basename }}"
+    - role: xanmanning.k3s

--- a/molecule/autodeploy/molecule.yml
+++ b/molecule/autodeploy/molecule.yml
@@ -21,32 +21,35 @@ scenario:
     - destroy
 platforms:
   - name: node1
-    image: ${MOLECULE_DISTRO:-"geerlingguy/docker-rockylinux8-ansible:latest"}
+    image: ${MOLECULE_DISTRO:-"geerlingguy/docker-rockylinux10-ansible:latest"}
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
     privileged: true
     pre_build_image: ${MOLECULE_PREBUILT:-true}
     networks:
       - name: k3snet
+    cgroupns_mode: host
   - name: node2
-    image: ${MOLECULE_DISTRO:-"geerlingguy/docker-rockylinux8-ansible:latest"}
+    image: ${MOLECULE_DISTRO:-"geerlingguy/docker-rockylinux10-ansible:latest"}
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
     privileged: true
     pre_build_image: ${MOLECULE_PREBUILT:-true}
     networks:
       - name: k3snet
+    cgroupns_mode: host
   - name: node3
-    image: ${MOLECULE_DISTRO:-"geerlingguy/docker-rockylinux8-ansible:latest"}
+    image: ${MOLECULE_DISTRO:-"geerlingguy/docker-rockylinux10-ansible:latest"}
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
     privileged: true
     pre_build_image: ${MOLECULE_PREBUILT:-true}
     networks:
       - name: k3snet
+    cgroupns_mode: host
 provisioner:
   name: ansible
   options:

--- a/molecule/debug/converge.yml
+++ b/molecule/debug/converge.yml
@@ -4,8 +4,10 @@
   become: true
   vars:
     pyratlabs_issue_controller_dump: true
-    # k3s_agent:
-    #   snapshotter: native
+    k3s_server:
+      snapshotter: native
+    k3s_agent:
+      snapshotter: native
   pre_tasks:
     - name: Ensure k3s_debug is set
       ansible.builtin.set_fact:

--- a/molecule/debug/molecule.yml
+++ b/molecule/debug/molecule.yml
@@ -21,32 +21,35 @@ scenario:
     - destroy
 platforms:
   - name: node1
-    image: ${MOLECULE_DISTRO:-"geerlingguy/docker-rockylinux8-ansible:latest"}
+    image: ${MOLECULE_DISTRO:-"geerlingguy/docker-rockylinux10-ansible:latest"}
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
     privileged: true
     pre_build_image: ${MOLECULE_PREBUILT:-true}
     networks:
       - name: k3snet
+    cgroupns_mode: host
   - name: node2
-    image: ${MOLECULE_DISTRO:-"geerlingguy/docker-rockylinux8-ansible:latest"}
+    image: ${MOLECULE_DISTRO:-"geerlingguy/docker-rockylinux10-ansible:latest"}
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
     privileged: true
     pre_build_image: ${MOLECULE_PREBUILT:-true}
     networks:
       - name: k3snet
+    cgroupns_mode: host
   - name: node3
-    image: ${MOLECULE_DISTRO:-"geerlingguy/docker-rockylinux8-ansible:latest"}
+    image: ${MOLECULE_DISTRO:-"geerlingguy/docker-rockylinux10-ansible:latest"}
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
     privileged: true
     pre_build_image: ${MOLECULE_PREBUILT:-true}
     networks:
       - name: k3snet
+    cgroupns_mode: host
 provisioner:
   name: ansible
   options:

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -3,10 +3,12 @@
   hosts: all
   become: true
   roles:
-    - role: "{{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY') | basename }}"
+    - role: xanmanning.k3s
       vars:
         molecule_is_test: true
         k3s_install_hard_links: true
         k3s_release_version: stable
-        # k3s_agent:
-          # snapshotter: native
+        k3s_server:
+          snapshotter: native
+        k3s_agent:
+          snapshotter: native

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -21,32 +21,35 @@ scenario:
     - destroy
 platforms:
   - name: node1
-    image: ${MOLECULE_DISTRO:-"geerlingguy/docker-rockylinux8-ansible:latest"}
+    image: ${MOLECULE_DISTRO:-"geerlingguy/docker-rockylinux10-ansible:latest"}
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
     privileged: true
     pre_build_image: ${MOLECULE_PREBUILT:-true}
     networks:
       - name: k3snet
+    cgroupns_mode: host
   - name: node2
-    image: ${MOLECULE_DISTRO:-"geerlingguy/docker-rockylinux8-ansible:latest"}
+    image: ${MOLECULE_DISTRO:-"geerlingguy/docker-rockylinux10-ansible:latest"}
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
     privileged: true
     pre_build_image: ${MOLECULE_PREBUILT:-true}
     networks:
       - name: k3snet
+    cgroupns_mode: host
   - name: node3
-    image: ${MOLECULE_DISTRO:-"geerlingguy/docker-rockylinux8-ansible:latest"}
+    image: ${MOLECULE_DISTRO:-"geerlingguy/docker-rockylinux10-ansible:latest"}
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
     privileged: true
     pre_build_image: ${MOLECULE_PREBUILT:-true}
     networks:
       - name: k3snet
+    cgroupns_mode: host
 provisioner:
   name: ansible
   options:

--- a/molecule/highavailabilitydb/converge.yml
+++ b/molecule/highavailabilitydb/converge.yml
@@ -9,8 +9,9 @@
     k3s_control_token: 55ba04e5-e17d-4535-9170-3e4245453f4d
     k3s_server:
       datastore-endpoint: "postgres://postgres:verybadpass@database:5432/postgres?sslmode=disable"
-    # k3s_agent:
-    #   snapshotter: native
+      snapshotter: native
+    k3s_agent:
+      snapshotter: native
     k3s_service_env_file: /tmp/k3s.env
   pre_tasks:
     - name: Set each node to be a control node
@@ -18,4 +19,4 @@
         k3s_control_node: true
       when: inventory_hostname in ['node2', 'node3']
   roles:
-    - role: "{{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY') | basename }}"
+    - role: xanmanning.k3s

--- a/molecule/highavailabilitydb/molecule.yml
+++ b/molecule/highavailabilitydb/molecule.yml
@@ -21,42 +21,46 @@ scenario:
     - destroy
 platforms:
   - name: node1
-    image: ${MOLECULE_DISTRO:-"geerlingguy/docker-rockylinux8-ansible:latest"}
+    image: ${MOLECULE_DISTRO:-"geerlingguy/docker-rockylinux10-ansible:latest"}
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
     privileged: true
     pre_build_image: ${MOLECULE_PREBUILT:-true}
     networks:
       - name: k3snet
+    cgroupns_mode: host
   - name: node2
-    image: ${MOLECULE_DISTRO:-"geerlingguy/docker-rockylinux8-ansible:latest"}
+    image: ${MOLECULE_DISTRO:-"geerlingguy/docker-rockylinux10-ansible:latest"}
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
     privileged: true
     pre_build_image: ${MOLECULE_PREBUILT:-true}
     networks:
       - name: k3snet
+    cgroupns_mode: host
   - name: node3
-    image: ${MOLECULE_DISTRO:-"geerlingguy/docker-rockylinux8-ansible:latest"}
+    image: ${MOLECULE_DISTRO:-"geerlingguy/docker-rockylinux10-ansible:latest"}
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
     privileged: true
     pre_build_image: ${MOLECULE_PREBUILT:-true}
     networks:
       - name: k3snet
+    cgroupns_mode: host
   - name: database
-    image: postgres:11-alpine
+    image: postgres:17-alpine
     pre_build_image: true
     command: "postgres"
     env:
       POSTGRES_PASSWORD: "verybadpass"
     networks:
       - name: k3snet
+    cgroupns_mode: host
   - name: loadbalancer
-    image: geerlingguy/docker-rockylinux8-ansible:latest
+    image: geerlingguy/docker-rockylinux10-ansible:latest
     pre_build_image: true
     ports:
       - "6443:6443"

--- a/molecule/highavailabilityetcd/converge.yml
+++ b/molecule/highavailabilityetcd/converge.yml
@@ -10,6 +10,7 @@
     k3s_etcd_datastore: true
     k3s_server:
       secrets-encryption: true
+      snapshotter: native
     k3s_agent:
       node-ip: "{{ ansible_default_ipv4.address }}"
       snapshotter: native
@@ -21,4 +22,4 @@
       ansible.builtin.set_fact:
         k3s_control_node: true
   roles:
-    - role: "{{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY') | basename }}"
+    - role: xanmanning.k3s

--- a/molecule/highavailabilityetcd/converge.yml
+++ b/molecule/highavailabilityetcd/converge.yml
@@ -5,7 +5,7 @@
   become: true
   vars:
     molecule_is_test: true
-    k3s_release_version: "v1.21"
+    k3s_release_version: "v1.33"
     k3s_use_experimental: true
     k3s_etcd_datastore: true
     k3s_server:

--- a/molecule/highavailabilityetcd/molecule.yml
+++ b/molecule/highavailabilityetcd/molecule.yml
@@ -21,34 +21,37 @@ scenario:
     - destroy
 platforms:
   - name: node1
-    image: ${MOLECULE_DISTRO:-"geerlingguy/docker-rockylinux8-ansible:latest"}
+    image: ${MOLECULE_DISTRO:-"geerlingguy/docker-rockylinux10-ansible:latest"}
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
     privileged: true
     pre_build_image: ${MOLECULE_PREBUILT:-true}
     networks:
       - name: k3snet
+    cgroupns_mode: host
   - name: node2
-    image: ${MOLECULE_DISTRO:-"geerlingguy/docker-rockylinux8-ansible:latest"}
+    image: ${MOLECULE_DISTRO:-"geerlingguy/docker-rockylinux10-ansible:latest"}
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
     privileged: true
     pre_build_image: ${MOLECULE_PREBUILT:-true}
     networks:
       - name: k3snet
+    cgroupns_mode: host
   - name: node3
-    image: ${MOLECULE_DISTRO:-"geerlingguy/docker-rockylinux8-ansible:latest"}
+    image: ${MOLECULE_DISTRO:-"geerlingguy/docker-rockylinux10-ansible:latest"}
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
     privileged: true
     pre_build_image: ${MOLECULE_PREBUILT:-true}
     networks:
       - name: k3snet
+    cgroupns_mode: host
   - name: loadbalancer
-    image: geerlingguy/docker-rockylinux8-ansible:latest
+    image: geerlingguy/docker-rockylinux10-ansible:latest
     pre_build_image: true
     ports:
       - "6443:6443"

--- a/molecule/lint-requirements.txt
+++ b/molecule/lint-requirements.txt
@@ -1,4 +1,4 @@
 -r ../requirements.txt
 
-yamllint>=1.25.0
-ansible-lint>=4.3.5
+yamllint>=1.37.1
+ansible-lint>=25.6.1

--- a/molecule/nodeploy/converge.yml
+++ b/molecule/nodeploy/converge.yml
@@ -9,4 +9,4 @@
     k3s_airgap: true
     k3s_release_version: latest
   roles:
-    - role: "{{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY') | basename }}"
+    - role: xanmanning.k3s

--- a/molecule/nodeploy/k3s_agent.yml
+++ b/molecule/nodeploy/k3s_agent.yml
@@ -6,4 +6,4 @@ node-label:
 kubelet-arg:
   - "cloud-provider=external"
   - "provider-id=azure"
-# snapshotter: native
+snapshotter: native

--- a/molecule/nodeploy/k3s_server.yml
+++ b/molecule/nodeploy/k3s_server.yml
@@ -12,3 +12,4 @@ disable:
   - metrics-server
 node-taint:
   - "k3s-controlplane=true:NoExecute"
+snapshotter: native

--- a/molecule/nodeploy/molecule.yml
+++ b/molecule/nodeploy/molecule.yml
@@ -21,32 +21,35 @@ scenario:
     - destroy
 platforms:
   - name: node1
-    image: ${MOLECULE_DISTRO:-"geerlingguy/docker-rockylinux8-ansible:latest"}
+    image: ${MOLECULE_DISTRO:-"geerlingguy/docker-rockylinux10-ansible:latest"}
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
     privileged: true
     pre_build_image: ${MOLECULE_PREBUILT:-true}
     networks:
       - name: k3snet
+    cgroupns_mode: host
   - name: node2
-    image: ${MOLECULE_DISTRO:-"geerlingguy/docker-rockylinux8-ansible:latest"}
+    image: ${MOLECULE_DISTRO:-"geerlingguy/docker-rockylinux10-ansible:latest"}
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
     privileged: true
     pre_build_image: ${MOLECULE_PREBUILT:-true}
     networks:
       - name: k3snet
+    cgroupns_mode: host
   - name: node3
-    image: ${MOLECULE_DISTRO:-"geerlingguy/docker-rockylinux8-ansible:latest"}
+    image: ${MOLECULE_DISTRO:-"geerlingguy/docker-rockylinux10-ansible:latest"}
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
     privileged: true
     pre_build_image: ${MOLECULE_PREBUILT:-true}
     networks:
       - name: k3snet
+    cgroupns_mode: host
 provisioner:
   name: ansible
   options:

--- a/molecule/nodeploy/prepare.yml
+++ b/molecule/nodeploy/prepare.yml
@@ -22,6 +22,6 @@
 
         - name: Ensure k3s is downloaded for air-gap installation
           ansible.builtin.get_url:
-            url: https://github.com/k3s-io/k3s/releases/download/v1.22.5%2Bk3s1/k3s
+            url: https://github.com/k3s-io/k3s/releases/download/v1.33.1%2Bk3s1/k3s
             dest: ./files/k3s
             mode: 0755

--- a/molecule/requirements.txt
+++ b/molecule/requirements.txt
@@ -1,4 +1,5 @@
 -r ../requirements.txt
 
 molecule-plugins[docker]
-docker>=4.3.1
+docker>=7.1.0
+netaddr>=1.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-ansible>=2.10.7
+ansible>=11.7.0

--- a/tasks/ensure_drain_and_remove_nodes.yml
+++ b/tasks/ensure_drain_and_remove_nodes.yml
@@ -28,7 +28,7 @@
         cmd: >-
           {{ k3s_install_dir }}/kubectl drain {{ hostvars[item].ansible_hostname }}
             --ignore-daemonsets
-            --{{ k3s_drain_command[ansible_version.string is version_compare('1.22', '>=')] }}
+            --{{ k3s_drain_command[ansible_version.string is version_compare('1.33', '>=')] }}
             --force
       delegate_to: "{{ k3s_control_delegate }}"
       run_once: true

--- a/tasks/ensure_pre_configuration.yml
+++ b/tasks/ensure_pre_configuration.yml
@@ -147,7 +147,7 @@
 
     - name: Ensure the node registration address is defined from node-ip
       ansible.builtin.set_fact:
-        k3s_registration_address: "{{ (hostvars[k3s_control_delegate].k3s_node_ip | split(','))[0] | ipwrap }}"
+        k3s_registration_address: "{{ (hostvars[k3s_control_delegate].k3s_node_ip | split(','))[0] | ansible.utils.ipwrap }}"
       check_mode: false
       when:
         - k3s_registration_address is not defined

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -128,7 +128,7 @@ k3s_check_packages:
   debian-11:
     - name: iptables-legacy
       from: 1.19.2
-      until: 1.22.3
+      until: 1.33.1
       documentation: https://rancher.com/docs/k3s/latest/en/advanced/#enabling-legacy-iptables-on-raspbian-buster
 # - name: dummy
 #   from: 1.19.2


### PR DESCRIPTION
## TITLE

### Summary

- Add tests for Ubuntu 24.04, drop tests for Ubuntu 20.04
- Add tests for Fedora 41, 42, drop tests for Fedora 33, 34, 35
- Remove testing for amazonlinux2 (https://github.com/geerlingguy/docker-amazonlinux2-ansible is archived)
- Remove testing for Alpine (3.16 is way EoL) and no 3.22 image exist for our use-case.
- Fixed tests
- Bumped workflow deps
- Bumped Python deps
- Added uv to workflow
- Updated tested k3s version from 1.22 to 1.33
- Updated postgres:11 to postgres:17 in tests
- Added netaddr as python dep
- Force snapshotter to be native to further fix molecule tests
- Added mise config for local dev env

Need to continue using the ubuntu-22.04 runner due to 

https://github.com/geerlingguy/docker-fedora41-ansible/issues/2

### Issue type

<!-- Pick one below and delete the rest -->
- Bugfix

### Test instructions

<!-- Please provide instructions for testing this PR -->

### Acceptance Criteria

<!-- Please list criteria required to ensure this change has been sufficiently reviewed.  -->

<!-- Example ticklist:
  - [ ] GitHub Actions Build passes.
  - [ ] Documentation updated.
-->

### Additional Information

<!-- Include additional information to help people understand the change here -->

<!-- Paste verbatim command output below, e.g. before and after your change -->

```text

```
