### PR TITLE
Document netaddr dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ The host you're running Ansible from requires the following Python dependencies:
 
   - `python >= 3.6.0` - [See Notes below](#important-note-about-python).
   - `ansible >= 2.9.16` or `ansible-base >= 2.10.4`
+  - `netaddr >= 1.3.0` - Required for dual-stack IP address handling
 
 You can install dependencies using the requirements.txt file in this repository:
 `pip3 install -r requirements.txt`.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 ansible>=11.7.0
+netaddr>=1.3.0


### PR DESCRIPTION
## netaddr

### Summary

This PR just adds `netaddr` as a dependency and the README. Netaddr was added under #230 through the use of `ipwrap` to handle the IPv6 brackets. [ipwrap](https://docs.ansible.com/ansible/latest/collections/ansible/utils/docsite/filters_ipaddr.html?utm_source=chatgpt.com#wrapping-ipv6-addresses-in-brackets) requires `netaddr`.

I found this after one of my pipelines failed.

### Issue type

- Documentation