### PR TITLE
Fix directory default mode

### DIFF
--- a/tasks/ensure_directories.yml
+++ b/tasks/ensure_directories.yml
@@ -4,7 +4,7 @@
   ansible.builtin.file:
     path: "{{ directory.path }}"
     state: directory
-    mode: "{{ directory.mode | default(755) }}"
+    mode: "{{ directory.mode | default('755') }}"
   become: "{{ k3s_become }}"
   when:
     - directory.path is defined


### PR DESCRIPTION
## Fix directory default mode

### Summary

As per [Ansible documentation](https://docs.ansible.com/projects/ansible/latest/collections/ansible/builtin/file_module.html), octal file mode definition must be quoted:

> For consistent results, quote octal numbers (for example, '644' or '1777')


### Issue type

- Bugfix

### Test instructions

- run role with `-C --diff` parameters on a setup with and without this commit
- apply the role and validate effective file permissions afterwards

### Acceptance Criteria

<!-- Please list criteria required to ensure this change has been sufficiently reviewed.  -->


  - [ ] GitHub Actions Build passes.


### Additional Information

<!-- Include additional information to help people understand the change here -->

<!-- Paste verbatim command output below, e.g. before and after your change -->

Unquoted, the value is converted and applied as `01363`, as seen in the following Ansible diff output from applying the role to an existing setup _without_ this fix.

```
TASK [xanmanning.k3s : Ensure Config directory exists] *******************
--- before
+++ after
@@ -1,4 +1,4 @@
 {
-    "mode": "0755",
+    "mode": "01363",
     "path": "/etc/rancher/k3s"
 }
```

Tested with versions:
```
ansible [core 2.19.4]
  python version = 3.13.9 (main, Oct 14 2025, 13:52:31) [GCC 12.3.0] 
  jinja version = 3.1.6
  pyyaml version = 6.0.3 (with libyaml v0.2.5)
  ```

