### PR TITLE
fix dummy cluster token for ansible_check_mode

### DIFF
--- a/tasks/ensure_cluster.yml
+++ b/tasks/ensure_cluster.yml
@@ -22,6 +22,7 @@
     k3s_control_token_content: "{{ k3s_control_delegate | to_uuid }}"
   check_mode: false
   when:
+    - k3s_control_token is not defined
     - ansible_check_mode
 
 - name: Ensure the cluster token file location exists


### PR DESCRIPTION
Rebases #237 - Original author: @Haran

Fixes the task to not run if k3s_control_token is already defined.