### PR TITLE
Fix deprecation warnings 

### DIFF
--- a/molecule/autodeploy/prepare.yml
+++ b/molecule/autodeploy/prepare.yml
@@ -8,7 +8,7 @@
         name: iptables
         state: present
         update_cache: true
-      when: ansible_pkg_mgr == 'apt'
+      when: ansible_facts['pkg_mgr'] == 'apt'
 
     - name: Ensure install directory and configuration directory exists
       ansible.builtin.file:

--- a/molecule/debug/prepare.yml
+++ b/molecule/debug/prepare.yml
@@ -7,4 +7,4 @@
         name: iptables
         state: present
         update_cache: true
-      when: ansible_pkg_mgr == 'apt'
+      when: ansible_facts['pkg_mgr'] == 'apt'

--- a/molecule/default/playbook-rootless.yml
+++ b/molecule/default/playbook-rootless.yml
@@ -10,6 +10,6 @@
       rootless: true
     k3s_agent:
       rootless: true
-    k3s_install_dir: "/home/{{ ansible_user_id }}/bin"
+    k3s_install_dir: "/home/{{ ansible_facts['user_id'] }}/bin"
   roles:
     - role: "{{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY') | basename }}"

--- a/molecule/default/prepare.yml
+++ b/molecule/default/prepare.yml
@@ -7,4 +7,4 @@
         name: iptables
         state: present
         update_cache: true
-      when: ansible_pkg_mgr == 'apt'
+      when: ansible_facts['pkg_mgr'] == 'apt'

--- a/molecule/highavailabilitydb/prepare.yml
+++ b/molecule/highavailabilitydb/prepare.yml
@@ -5,7 +5,7 @@
     - name: Ensure apt cache is updated
       ansible.builtin.apt:
         update_cache: true
-      when: ansible_pkg_mgr == 'apt'
+      when: ansible_facts['pkg_mgr'] == 'apt'
 
     - name: Ensure HAProxy is installed
       ansible.builtin.package:
@@ -38,11 +38,11 @@
         name: iptables
         state: present
         update_cache: true
-      when: ansible_pkg_mgr == 'apt'
+      when: ansible_facts['pkg_mgr'] == 'apt'
 
     - name: Ensure environment file exists for k3s_service_env_file
       ansible.builtin.lineinfile:
         path: /tmp/k3s.env
-        line: "THISHOST={{ ansible_hostname }}"
+        line: "THISHOST={{ ansible_facts['hostname'] }}"
         mode: 0644
         create: true

--- a/molecule/highavailabilityetcd/converge.yml
+++ b/molecule/highavailabilityetcd/converge.yml
@@ -12,11 +12,11 @@
       secrets-encryption: true
       snapshotter: native
     k3s_agent:
-      node-ip: "{{ ansible_default_ipv4.address }}"
+      node-ip: "{{ ansible_facts['default_ipv4'].address }}"
       snapshotter: native
-      selinux: "{{ ansible_os_family | lower == 'redhat' }}"
-    k3s_skip_validation: "{{ k3s_service_handler[ansible_service_mgr] == 'service' }}"
-    # k3s_skip_post_checks: "{{ ansible_os_family | lower == 'redhat' }}"
+      selinux: "{{ ansible_facts['os_family'] | lower == 'redhat' }}"
+    k3s_skip_validation: "{{ k3s_service_handler[ansible_facts['service_mgr']] == 'service' }}"
+    # k3s_skip_post_checks: "{{ ansible_facts['os_family'] | lower == 'redhat' }}"
   pre_tasks:
     - name: Set each node to be a control node
       ansible.builtin.set_fact:

--- a/molecule/highavailabilityetcd/prepare.yml
+++ b/molecule/highavailabilityetcd/prepare.yml
@@ -6,14 +6,14 @@
     - name: Ensure apt cache is updated
       ansible.builtin.apt:
         update_cache: true
-      when: ansible_pkg_mgr == 'apt'
+      when: ansible_facts['pkg_mgr'] == 'apt'
 
     - name: Ensure sudo is installed
       community.general.apk:
         name: sudo
         state: present
         update_cache: true
-      when: ansible_pkg_mgr == 'apk'
+      when: ansible_facts['pkg_mgr'] == 'apk'
 
 - name: Prepare Load Balancer
   hosts: loadbalancer
@@ -49,11 +49,11 @@
         name: iptables
         state: present
         update_cache: true
-      when: ansible_pkg_mgr == 'apt'
+      when: ansible_facts['pkg_mgr'] == 'apt'
 
     - name: Ensure iproute is installed
       ansible.builtin.dnf:
         name: iproute
         state: present
         update_cache: true
-      when: ansible_pkg_mgr == 'dnf'
+      when: ansible_facts['pkg_mgr'] == 'dnf'

--- a/molecule/nodeploy/prepare.yml
+++ b/molecule/nodeploy/prepare.yml
@@ -7,7 +7,7 @@
         name: iptables
         state: present
         update_cache: true
-      when: ansible_pkg_mgr == 'apt'
+      when: ansible_facts['pkg_mgr'] == 'apt'
 
     - name: Prepare air-gapped installation
       delegate_to: localhost

--- a/tasks/determine_systemd_context.yml
+++ b/tasks/determine_systemd_context.yml
@@ -3,7 +3,7 @@
 - name: Ensure systemd context is correct if we are running k3s rootless
   ansible.builtin.set_fact:
     k3s_systemd_context: user
-    k3s_systemd_unit_dir: "{{ ansible_user_dir }}/.config/systemd/user"
+    k3s_systemd_unit_dir: "{{ ansible_facts['user_dir'] }}/.config/systemd/user"
   when:
     - k3s_runtime_config is defined
     - k3s_runtime_config.rootless is defined

--- a/tasks/ensure_cluster.yml
+++ b/tasks/ensure_cluster.yml
@@ -38,7 +38,7 @@
     mode: 0600
   become: "{{ k3s_become }}"
   notify:
-    - "Restart k3s {{ k3s_service_handler[ansible_service_mgr] }}"
+    - "Restart k3s {{ k3s_service_handler[ansible_facts['service_mgr']] }}"
 
 - name: Ensure k3s service unit file is present
   ansible.builtin.template:
@@ -47,10 +47,10 @@
     mode: 0644
   become: "{{ k3s_become }}"
   when:
-    - k3s_service_handler[ansible_service_mgr] == 'systemd'
+    - k3s_service_handler[ansible_facts['service_mgr']] == 'systemd'
   notify:
-    - "Reload {{ k3s_service_handler[ansible_service_mgr] }}"
-    - "Restart k3s {{ k3s_service_handler[ansible_service_mgr] }}"
+    - "Reload {{ k3s_service_handler[ansible_facts['service_mgr']] }}"
+    - "Restart k3s {{ k3s_service_handler[ansible_facts['service_mgr']] }}"
 
 - name: Ensure k3s service file is present
   ansible.builtin.template:
@@ -58,10 +58,10 @@
     dest: "{{ k3s_openrc_service_dir }}/k3s"
     mode: 0744
   when:
-    - k3s_service_handler[ansible_service_mgr] == 'service'
+    - k3s_service_handler[ansible_facts['service_mgr']] == 'service'
   notify:
-    - "Reload {{ k3s_service_handler[ansible_service_mgr] }}"
-    - "Restart k3s {{ k3s_service_handler[ansible_service_mgr] }}"
+    - "Reload {{ k3s_service_handler[ansible_facts['service_mgr']] }}"
+    - "Restart k3s {{ k3s_service_handler[ansible_facts['service_mgr']] }}"
   become: "{{ k3s_become }}"
 
 - name: Ensure k3s logrotate file is present
@@ -70,10 +70,10 @@
     dest: "{{ k3s_logrotate_dir }}/k3s"
     mode: 0640
   when:
-    - k3s_service_handler[ansible_service_mgr] == 'service'
+    - k3s_service_handler[ansible_facts['service_mgr']] == 'service'
   notify:
-    - "Reload {{ k3s_service_handler[ansible_service_mgr] }}"
-    - "Restart k3s {{ k3s_service_handler[ansible_service_mgr] }}"
+    - "Reload {{ k3s_service_handler[ansible_facts['service_mgr']] }}"
+    - "Restart k3s {{ k3s_service_handler[ansible_facts['service_mgr']] }}"
   become: "{{ k3s_become }}"
 
 - name: Ensure k3s config file exists
@@ -82,12 +82,12 @@
     dest: "{{ k3s_config_file }}"
     mode: 0644
   notify:
-    - "Reload {{ k3s_service_handler[ansible_service_mgr] }}"
-    - "Restart k3s {{ k3s_service_handler[ansible_service_mgr] }}"
+    - "Reload {{ k3s_service_handler[ansible_facts['service_mgr']] }}"
+    - "Restart k3s {{ k3s_service_handler[ansible_facts['service_mgr']] }}"
   become: "{{ k3s_become }}"
 
 - name: Ensure secondary controllers are started
-  ansible.builtin.include_tasks: ensure_control_plane_started_{{ ansible_service_mgr }}.yml
+  ansible.builtin.include_tasks: ensure_control_plane_started_{{ ansible_facts['service_mgr'] }}.yml
   when:
     - k3s_control_node
     - not k3s_primary_control_node

--- a/tasks/ensure_containerd_registries.yml
+++ b/tasks/ensure_containerd_registries.yml
@@ -6,6 +6,6 @@
     dest: "{{ k3s_config_dir }}/registries.yaml"
     mode: 0600
   notify:
-    - "Reload {{ k3s_service_handler[ansible_service_mgr] }}"
-    - "Restart k3s {{ k3s_service_handler[ansible_service_mgr] }}"
+    - "Reload {{ k3s_service_handler[ansible_facts['service_mgr']] }}"
+    - "Restart k3s {{ k3s_service_handler[ansible_facts['service_mgr']] }}"
   become: "{{ k3s_become }}"

--- a/tasks/ensure_downloads.yml
+++ b/tasks/ensure_downloads.yml
@@ -2,8 +2,8 @@
 
 - name: Ensure target host architecture information is set as a fact
   ansible.builtin.set_fact:
-    k3s_arch: "{{ k3s_arch_lookup[ansible_architecture].arch }}"
-    k3s_arch_suffix: "{{ k3s_arch_lookup[ansible_architecture].suffix }}"
+    k3s_arch: "{{ k3s_arch_lookup[ansible_facts['architecture']].arch }}"
+    k3s_arch_suffix: "{{ k3s_arch_lookup[ansible_facts['architecture']].suffix }}"
   check_mode: false
 
 - name: Ensure URLs are set as facts for downloading binaries
@@ -17,7 +17,7 @@
     k3s_binary_url: "https://storage.googleapis.com/k3s-ci-builds/k3s{{ k3s_arch_suffix }}-{{ k3s_release_version }}"
     k3s_hash_url: "https://storage.googleapis.com/k3s-ci-builds/k3s{{ k3s_arch_suffix }}-{{ k3s_release_version }}.sha256sum"
   when:
-    - k3s_release_version | regex_search("^[a-z0-9]{40}$") | bool
+    - k3s_release_version | regex_search("^[a-z0-9]{40}$") != None
   check_mode: false
 
 - name: Ensure the k3s hashsum is downloaded

--- a/tasks/ensure_drain_and_remove_nodes.yml
+++ b/tasks/ensure_drain_and_remove_nodes.yml
@@ -26,7 +26,7 @@
     - name: Ensure uninstalled nodes are drained # noqa no-changed-when
       ansible.builtin.command:
         cmd: >-
-          {{ k3s_install_dir }}/kubectl drain {{ hostvars[item].ansible_hostname }}
+          {{ k3s_install_dir }}/kubectl drain {{ hostvars[item].ansible_facts['hostname'] }}
             --ignore-daemonsets
             --{{ k3s_drain_command[ansible_version.string is version_compare('1.33', '>=')] }}
             --force
@@ -34,7 +34,7 @@
       run_once: true
       when:
         - kubectl_get_nodes_result.stdout is defined
-        - hostvars[item].ansible_hostname in kubectl_get_nodes_result.stdout
+        - hostvars[item].ansible_facts['hostname'] in kubectl_get_nodes_result.stdout
         - hostvars[item].k3s_state is defined
         - hostvars[item].k3s_state == 'uninstalled'
       loop: "{{ ansible_play_hosts }}"
@@ -42,12 +42,12 @@
 
     - name: Ensure uninstalled nodes are removed # noqa no-changed-when
       ansible.builtin.command:
-        cmd: "{{ k3s_install_dir }}/kubectl delete node {{ hostvars[item].ansible_hostname }}"
+        cmd: "{{ k3s_install_dir }}/kubectl delete node {{ hostvars[item].ansible_facts['hostname'] }}"
       delegate_to: "{{ k3s_control_delegate }}"
       run_once: true
       when:
         - kubectl_get_nodes_result.stdout is defined
-        - hostvars[item].ansible_hostname in kubectl_get_nodes_result.stdout
+        - hostvars[item].ansible_facts['hostname'] in kubectl_get_nodes_result.stdout
         - hostvars[item].k3s_state is defined
         - hostvars[item].k3s_state == 'uninstalled'
       loop: "{{ ansible_play_hosts }}"

--- a/tasks/ensure_installed.yml
+++ b/tasks/ensure_installed.yml
@@ -25,8 +25,8 @@
     path: "{{ k3s_token_location }}"
   register: k3s_token_cluster_check
 
-- name: Ensure control plane started with {{ ansible_service_mgr }}
-  ansible.builtin.include_tasks: ensure_control_plane_started_{{ ansible_service_mgr }}.yml
+- name: Ensure control plane started with {{ ansible_facts['service_mgr'] }}
+  ansible.builtin.include_tasks: ensure_control_plane_started_{{ ansible_facts['service_mgr'] }}.yml
   when: (k3s_control_node and k3s_controller_list | length == 1)
         or (k3s_primary_control_node and k3s_controller_list | length > 1)
         or k3s_token_cluster_check.stat.exists

--- a/tasks/ensure_installed_node.yml
+++ b/tasks/ensure_installed_node.yml
@@ -14,7 +14,7 @@
     - ctr
   when: not ansible_check_mode
   notify:
-    - "Restart k3s {{ k3s_service_handler[ansible_service_mgr] }}"
+    - "Restart k3s {{ k3s_service_handler[ansible_facts['service_mgr']] }}"
   become: "{{ k3s_become }}"
 
 - name: Ensure k3s config file exists
@@ -23,8 +23,8 @@
     dest: "{{ k3s_config_file }}"
     mode: 0644
   notify:
-    - "Reload {{ k3s_service_handler[ansible_service_mgr] }}"
-    - "Restart k3s {{ k3s_service_handler[ansible_service_mgr] }}"
+    - "Reload {{ k3s_service_handler[ansible_facts['service_mgr']] }}"
+    - "Restart k3s {{ k3s_service_handler[ansible_facts['service_mgr']] }}"
   become: "{{ k3s_become }}"
 
 - name: Ensure cluster token is present when pre-defined
@@ -44,7 +44,7 @@
         mode: 0600
       become: "{{ k3s_become }}"
       notify:
-        - "Restart k3s {{ k3s_service_handler[ansible_service_mgr] }}"
+        - "Restart k3s {{ k3s_service_handler[ansible_facts['service_mgr']] }}"
 
 - name: Ensure k3s service unit file is present
   ansible.builtin.template:
@@ -52,10 +52,10 @@
     dest: "{{ k3s_systemd_unit_dir }}/k3s.service"
     mode: 0644
   when:
-    - k3s_service_handler[ansible_service_mgr] == 'systemd'
+    - k3s_service_handler[ansible_facts['service_mgr']] == 'systemd'
   notify:
-    - "Reload {{ k3s_service_handler[ansible_service_mgr] }}"
-    - "Restart k3s {{ k3s_service_handler[ansible_service_mgr] }}"
+    - "Reload {{ k3s_service_handler[ansible_facts['service_mgr']] }}"
+    - "Restart k3s {{ k3s_service_handler[ansible_facts['service_mgr']] }}"
   become: "{{ k3s_become }}"
 
 - name: Ensure k3s service file is present
@@ -64,10 +64,10 @@
     dest: "{{ k3s_openrc_service_dir }}/k3s"
     mode: 0744
   when:
-    - k3s_service_handler[ansible_service_mgr] == 'service'
+    - k3s_service_handler[ansible_facts['service_mgr']] == 'service'
   notify:
-    - "Reload {{ k3s_service_handler[ansible_service_mgr] }}"
-    - "Restart k3s {{ k3s_service_handler[ansible_service_mgr] }}"
+    - "Reload {{ k3s_service_handler[ansible_facts['service_mgr']] }}"
+    - "Restart k3s {{ k3s_service_handler[ansible_facts['service_mgr']] }}"
   become: "{{ k3s_become }}"
 
 - name: Ensure k3s logrotate file is present
@@ -76,10 +76,10 @@
     dest: "{{ k3s_logrotate_dir }}/k3s"
     mode: 0640
   when:
-    - k3s_service_handler[ansible_service_mgr] == 'service'
+    - k3s_service_handler[ansible_facts['service_mgr']] == 'service'
   notify:
-    - "Reload {{ k3s_service_handler[ansible_service_mgr] }}"
-    - "Restart k3s {{ k3s_service_handler[ansible_service_mgr] }}"
+    - "Reload {{ k3s_service_handler[ansible_facts['service_mgr']] }}"
+    - "Restart k3s {{ k3s_service_handler[ansible_facts['service_mgr']] }}"
   become: "{{ k3s_become }}"
 
 - name: Ensure k3s killall script is present

--- a/tasks/ensure_pre_configuration.yml
+++ b/tasks/ensure_pre_configuration.yml
@@ -101,7 +101,7 @@
     - k3s_build_cluster
     - k3s_control_delegate is not defined
 
-- name: Ensure ansible_host is mapped to inventory_hostname
+- name: Ensure ansible_facts['host'] is mapped to inventory_hostname
   ansible.builtin.blockinfile:
     path: /tmp/inventory.txt
     block: |
@@ -109,7 +109,7 @@
       {% filter replace('\n', ' ') %}
       {{ host }}
       @@@
-      {{ hostvars[host].ansible_host | default(hostvars[host].ansible_fqdn) | string }}
+      {{ hostvars[host].ansible_facts['host'] | default(hostvars[host].ansible_facts['fqdn']) | string }}
       @@@
       C_{{ hostvars[host].k3s_control_node | string }}
       @@@
@@ -156,7 +156,7 @@
 
     - name: Ensure the node registration address is defined
       ansible.builtin.set_fact:
-        k3s_registration_address: "{{ hostvars[k3s_control_delegate].ansible_host | default(hostvars[k3s_control_delegate].ansible_fqdn) }}"
+        k3s_registration_address: "{{ hostvars[k3s_control_delegate].ansible_facts['host'] | default(hostvars[k3s_control_delegate].ansible_facts['fqdn']) }}"
       check_mode: false
       when:
         - k3s_registration_address is not defined

--- a/tasks/pre_checks.yml
+++ b/tasks/pre_checks.yml
@@ -23,14 +23,14 @@
     - not k3s_skip_validation
     - not k3s_skip_env_checks
 
-- name: Check that Python v{{ ansible_python_version }} is supported by this role
+- name: Check that Python v{{ ansible_facts['python_version'] }} is supported by this role
   ansible.builtin.assert:
     that:
-      - ansible_python_version is version_compare(k3s_python_min_version, '>=')
+      - ansible_facts['python_version'] is version_compare(k3s_python_min_version, '>=')
     fail_msg: >-
-      Python v{{ ansible_python_version }} is not supported by this role.
+      Python v{{ ansible_facts['python_version'] }} is not supported by this role.
       Please install >= v{{ k3s_python_min_version }}.
-    success_msg: "Python v{{ ansible_python_version }} is supported."
+    success_msg: "Python v{{ ansible_facts['python_version'] }} is supported."
   become: false
   delegate_to: localhost
   run_once: true
@@ -41,33 +41,33 @@
 - name: Check that the target init system is supported by this role
   ansible.builtin.assert:
     that:
-      - ansible_service_mgr in k3s_supported_init
+      - ansible_facts['service_mgr'] in k3s_supported_init
     fail_msg: >-
-      {{ ansible_service_mgr }} is not supported by this role.
+      {{ ansible_facts['service_mgr'] }} is not supported by this role.
       Supported init systems: {{ k3s_supported_init | join(', ') }}
-    success_msg: "{{ ansible_service_mgr }} is supported"
+    success_msg: "{{ ansible_facts['service_mgr'] }} is supported"
   when:
     - not k3s_skip_validation
     - not k3s_skip_env_checks
 
-- name: Determining if {{ ansible_service_mgr }} is actually openrc
+- name: Determining if {{ ansible_facts['service_mgr'] }} is actually openrc
   ansible.builtin.stat:
     path: /sbin/openrc-run
   register: k3s_check_openrc_run
   when:
-    - k3s_service_handler[ansible_service_mgr] == 'service'
+    - k3s_service_handler[ansible_facts['service_mgr']] == 'service'
     - not k3s_skip_validation
     - not k3s_skip_env_checks
 
-- name: Check that {{ ansible_service_mgr }} is actually openrc
+- name: Check that {{ ansible_facts['service_mgr'] }} is actually openrc
   ansible.builtin.assert:
     that:
       - k3s_check_openrc_run.stat.exists
     fail_msg: >-
-      openrc was not found, cannot install to {{ ansible_service_mgr }}
+      openrc was not found, cannot install to {{ ansible_facts['service_mgr'] }}
     success_msg: "openrc found"
   when:
-    - k3s_service_handler[ansible_service_mgr] == 'service'
+    - k3s_service_handler[ansible_facts['service_mgr']] == 'service'
     - not k3s_skip_validation
     - not k3s_skip_env_checks
 

--- a/tasks/pre_checks_control_node_count.yml
+++ b/tasks/pre_checks_control_node_count.yml
@@ -19,7 +19,7 @@
   ansible.builtin.assert:
     that:
       - (k3s_controller_list | length >= 2)
-      - (("datastore-endpoint" in k3s_runtime_config and k3s_runtime_config['datastore-endpoint'])
+      - (("datastore-endpoint" in k3s_runtime_config and (k3s_runtime_config['datastore-endpoint'] | length > 0))
           or (k3s_etcd_datastore is defined and k3s_etcd_datastore))
     success_msg: "Control plane configuration is valid."
     fail_msg: >-

--- a/tasks/pre_checks_unsupported_rootless.yml
+++ b/tasks/pre_checks_unsupported_rootless.yml
@@ -42,9 +42,9 @@
 - name: Get current user subuid and subgid values
   ansible.builtin.set_fact:
     k3s_current_user_subuid: "{{ (k3s_get_subuid['content'] | b64decode).split('\n')
-      | select('search', ansible_user_id) | first | default('UserNotFound:0:0') }}"
+      | select('search', ansible_facts['user_id']) | first | default('UserNotFound:0:0') }}"
     k3s_current_user_subgid: "{{ (k3s_get_subgid['content'] | b64decode).split('\n')
-      | select('search', ansible_user_id) | first | default('UserNotFound:0:0') }}"
+      | select('search', ansible_facts['user_id']) | first | default('UserNotFound:0:0') }}"
 
 - name: Check user namespaces kernel parameters are adequate
   ansible.builtin.assert:
@@ -55,7 +55,7 @@
       - k3s_current_user_subgid != "UserNotFound:0:0"
       - k3s_current_user_subuid.split(':')[2] | int >= 65536
       - k3s_current_user_subgid.split(':')[2] | int >= 65536
-      - ansible_env['XDG_RUNTIME_DIR'] is defined
+      - ansible_facts['env']['XDG_RUNTIME_DIR'] is defined
       - k3s_check_newuidmap_installed.rc == 0
     success_msg: All kernel parameters passed
     fail_msg: >-

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -118,10 +118,10 @@ k3s_server_manifests_dir: "{{ k3s_data_dir }}/server/manifests"
 k3s_server_pod_manifests_dir: "{{ k3s_data_dir }}/agent/pod-manifests"
 
 # OS formatted strings
-k3s_os_distribution: "{{ ansible_distribution | replace(' ', '-') | lower }}"
-k3s_os_version: "{{ ansible_distribution_version | replace([' ', '.'], '-') | lower }}"
+k3s_os_distribution: "{{ ansible_facts['distribution'] | replace(' ', '-') | lower }}"
+k3s_os_version: "{{ ansible_facts['distribution_version'] | replace([' ', '.'], '-') | lower }}"
 k3s_os_distribution_version: "{{ k3s_os_distribution }}-{{ k3s_os_version }}"
-k3s_os_family: "{{ ansible_os_family | replace(' ', '-') | lower }}"
+k3s_os_family: "{{ ansible_facts['os_family'] | replace(' ', '-') | lower }}"
 
 # Packages that we need to check are installed
 k3s_check_packages:


### PR DESCRIPTION
## Fix deprecation warnings

### Summary

Minor tweaks  to fix deprecation warnings introduced in Ansible 12 and 13.

[[Ansible 13 Porting Guide: Inject Facts As Vars](https://docs.ansible.com/projects/ansible/latest/porting_guides/porting_guide_13.html#inject-facts-as-vars)]( https://docs.ansible.com/projects/ansible/latest/porting_guides/porting_guide_13.html#inject-facts-as-vars)
Facts such as `ansible_os_distribution` are deprecated  and should be written as `ansible_facts['distribution']`

[[Ansible 12 Porting Guide: Implicit Boolean Conversion](https://docs.ansible.com/projects/ansible/latest/porting_guides/porting_guide_12.html#example-implicit-boolean-conversion)](https://docs.ansible.com/projects/ansible/latest/porting_guides/porting_guide_12.html#example-implicit-boolean-conversion)
Avoid implicit use of non-boolean values as conditionals: `k3s_runtime_config['datastore-endpoint']` should be `(k3s_runtime_config['datastore-endpoint'] | length > 0)`

### Issue type

- Bugfix

- ### Test instructions

None

### Acceptance Criteria

  - [x] GitHub Actions Build passes.


### Additional Information

Example warnings addressed by this change:
```text
[DEPRECATION WARNING]: INJECT_FACTS_AS_VARS default to `True` is deprecated, top-level facts will not be auto injected after the change. This feature will be removed from ansible-core version 2.24.
[DEPRECATION WARNING]: The `bool` filter coerced invalid value None (NoneType) to False. This feature will be removed from ansible-core version 2.23.

```
