### PR TITLE
Fix check-mode handling for existing cluster token

### DIFF
--- a/tasks/ensure_cluster.yml
+++ b/tasks/ensure_cluster.yml
@@ -25,7 +25,7 @@
   ansible.builtin.set_fact:
     k3s_control_token_content: "{{ k3s_control_token | default(k3s_slurped_cluster_token.content | b64decode) }}"
   when:
-    - k3s_control_token is defined or (k3s_slurped_cluster_token is defined and k3s_slurped_cluster_token is succeeded)
+    - k3s_control_token is defined or k3s_slurped_cluster_token.content is defined
 
 - name: Ensure dummy cluster token is defined for ansible_check_mode
   ansible.builtin.set_fact:

--- a/tasks/ensure_cluster.yml
+++ b/tasks/ensure_cluster.yml
@@ -1,5 +1,16 @@
 ---
 
+- name: Check if cluster token file exists on delegate in ansible_check_mode
+  ansible.builtin.stat:
+    path: "{{ k3s_runtime_config['data-dir'] | default(k3s_data_dir) }}/server/token"
+  register: k3s_token_file_check
+  delegate_to: "{{ k3s_control_delegate }}"
+  check_mode: false
+  when:
+    - k3s_control_token is not defined
+    - ansible_check_mode
+  become: "{{ k3s_become }}"
+
 - name: "Ensure cluster token is captured from {{ k3s_control_delegate }}"
   ansible.builtin.slurp:
     path: "{{ k3s_runtime_config['data-dir'] | default(k3s_data_dir) }}/server/token"
@@ -7,15 +18,14 @@
   delegate_to: "{{ k3s_control_delegate }}"
   when:
     - k3s_control_token is not defined
-    - not ansible_check_mode
+    - not ansible_check_mode or (k3s_token_file_check.stat.exists | default(false))
   become: "{{ k3s_become }}"
 
 - name: Ensure cluster token is formatted correctly for use in templates
   ansible.builtin.set_fact:
     k3s_control_token_content: "{{ k3s_control_token | default(k3s_slurped_cluster_token.content | b64decode) }}"
   when:
-    - k3s_control_token is not defined
-    - not ansible_check_mode
+    - k3s_control_token is defined or (k3s_slurped_cluster_token is defined and k3s_slurped_cluster_token is succeeded)
 
 - name: Ensure dummy cluster token is defined for ansible_check_mode
   ansible.builtin.set_fact:
@@ -24,6 +34,7 @@
   when:
     - k3s_control_token is not defined
     - ansible_check_mode
+    - not k3s_token_file_check.stat.exists
 
 - name: Ensure the cluster token file location exists
   ansible.builtin.file:


### PR DESCRIPTION
## Summary
- stat the delegated cluster token in check mode before trying to read it
- read and format an existing delegated token in check mode so templates keep the real cluster token
- keep the dummy UUID fallback only for fresh check-mode installs where the delegated token file does not exist yet

## Why
The existing check-mode path skips reading and formatting an already-created cluster token, then defines a dummy UUID token. On an existing cluster this makes the token template report a replacement from the real token to the dummy value during check mode.

The previous dummy-token guard remains useful when `k3s_control_token` is supplied explicitly, but it does not help the common existing-cluster path where the role needs to read the delegated token from disk.

The dummy fallback is still needed for fresh check-mode installs without a token file, so this fix guards slurp with a check-mode stat and only uses the fallback when the token file is absent.

## Validation
- covered explicit `k3s_control_token` in check mode and confirmed it remains the selected token without stat/slurp/dummy fallback
- covered an existing delegated token in check mode and confirmed the role reads and formats the on-disk token, leaving the token template unchanged
- covered a fresh check-mode scenario without a token file and confirmed it skips slurp, defines the dummy token, and does not fail on an undefined token variable
- verified against an existing cluster in check mode; the cluster-token template task stayed unchanged